### PR TITLE
[iol2opc]: show blob selected for train

### DIFF
--- a/main/app/iol2opc/scripts/iol2opc.xml.template
+++ b/main/app/iol2opc/scripts/iol2opc.xml.template
@@ -116,7 +116,7 @@
                 <protocol>tcp</protocol>
         </connection>
         <connection>
-                <from>/icub/camcalib/left/out</from>
+                <from>/iol2opc/imgSel:o</from>
                 <to>/iolViewer/objectSelector/view</to>
                 <protocol>udp</protocol>
         </connection>

--- a/main/src/modules/systemVisual/iol2opc/include/module.h
+++ b/main/src/modules/systemVisual/iol2opc/include/module.h
@@ -56,6 +56,7 @@ protected:
     BufferedPort<Bottle>             getClickPort;
     BufferedPort<ImageOf<PixelBgr> > imgIn;
     BufferedPort<ImageOf<PixelBgr> > imgRtLocOut;
+    BufferedPort<ImageOf<PixelBgr> > imgSelBlobOut;
     BufferedPort<ImageOf<PixelBgr> > imgHistogram;
     Port imgClassifier;
 
@@ -65,8 +66,6 @@ protected:
     ImageOf<PixelBgr> imgRtLoc;
     Mutex mutexResources;
     Mutex mutexResourcesOpc;
-
-    string name;
 
     map<string,Filter*> histFiltersPool;
     int histFilterLength;
@@ -79,6 +78,8 @@ protected:
     Vector skim_blobs_x_bounds;
     Vector skim_blobs_y_bounds;
     Vector histObjLocation;
+
+    CvPoint clickLocation;
 
     friend class RtLocalization;
     friend class OpcUpdater;


### PR DESCRIPTION
Changes:

- Used `yInfo()` in place of `printf()`.
- The viewer devoted for click selection is now able to highlight the selected blob.
- The xml script has been updated accordingly.

@Tobias-Fischer, I'll have no chance to test this week these small changes; you could consider merging this PR and use it straightaway in your experiments.