### PR TITLE
Added to OPCClient::removeEntity() services

### DIFF
--- a/main/src/libraries/wrdac/include/wrdac/clients/opcClient.h
+++ b/main/src/libraries/wrdac/include/wrdac/clients/opcClient.h
@@ -252,6 +252,20 @@ public:
     Entity *getEntity(int id, bool forceUpdate = false);
 
     /**
+    * Removes an entity based on its name. 
+    * @param name The name of the entity to remove. 
+    * @return true/false iff succeeded/failed. 
+    */
+    bool removeEntity(const std::string &name);
+
+    /**
+    * Removes an entity based on its id.
+    * @param id The ID of the entity to retrieve. 
+    * @return true/false iff succeeded/failed. 
+    */
+    bool removeEntity(int id);
+
+    /**
     * Poll the OPC for all entities and relations and store them locally.
     * @param updateCache If this option is turned on the local cache will be wiped
     */

--- a/main/src/libraries/wrdac/src/opcClient.cpp
+++ b/main/src/libraries/wrdac/src/opcClient.cpp
@@ -249,6 +249,56 @@ Entity *OPCClient::getEntity(int id, bool forceUpdate)
     return newE;
 }
 
+bool OPCClient::removeEntity(const string &name)
+{
+    if (Entity *e=getEntity(name,true))
+    {
+        Bottle cmd,reply;
+        cmd.addVocab(Vocab::encode("del"));
+        Bottle &payLoad=cmd.addList().addList();
+        payLoad.addString("id");
+        payLoad.addInt(e->opc_id()); 
+
+        if (write(cmd,reply,isVerbose))
+        {
+            if (reply.get(0).asVocab()==VOCAB3('a','c','k'))
+            {
+                entitiesByID.erase(e->opc_id());
+                return true;
+            }
+            else
+                yError()<<"Unable to talk correctly to OPC";
+        }
+    }
+
+    return false;
+}
+
+bool OPCClient::removeEntity(int id)
+{
+    if (Entity *e=getEntity(id,true))
+    {
+        Bottle cmd,reply;
+        cmd.addVocab(Vocab::encode("del"));
+        Bottle &payLoad=cmd.addList().addList();
+        payLoad.addString("id");
+        payLoad.addInt(e->opc_id()); 
+
+        if (write(cmd,reply,isVerbose))
+        {
+            if (reply.get(0).asVocab()==VOCAB3('a','c','k'))
+            {
+                entitiesByID.erase(e->opc_id());
+                return true;
+            }
+            else
+                yError()<<"Unable to talk correctly to OPC";
+        }
+    }
+
+    return false;
+}
+
 //Returns the OPCid of a relation on the server side
 int OPCClient::getRelationID(
         Entity* subject,

--- a/main/src/modules/systemVisual/iol2opc/src/module.cpp
+++ b/main/src/modules/systemVisual/iol2opc/src/module.cpp
@@ -1024,17 +1024,7 @@ bool IOL2OPCBridge::remove_object(const string &name)
     if (it!=db.end())
         db.erase(it);
 
-    if (Entity *en=opc->getEntity(it->second.opc_id))
-    {
-        if (Object *obj=dynamic_cast<Object*>(en))
-        {
-            obj->m_present=false;
-            opc->commit(obj);
-            return true;
-        }
-    }
-
-    return false;
+    return opc->removeEntity(it->second.opc_id);
 }
 
 
@@ -1058,11 +1048,9 @@ bool IOL2OPCBridge::remove_all()
     yInfo("Received reply: %s",replyClassifier.toString().c_str());
 
     for (map<string,IOLObject>::iterator it=db.begin(); it!=db.end(); it++)
-        dynamic_cast<Object*>(opc->getEntity(it->second.opc_id))->m_present=false;
+        opc->removeEntity(it->second.opc_id);
 
-    opc->commit();
     db.clear();
-
     return true;
 }
 


### PR DESCRIPTION
**`OPCClient`** now provides also services to remove entities (namely `removeEntity()`).
Further, **`iol2opc`** calls `OPCClient::removeEntity()` upon `remove_object` and `remove_all`.

/cc @Tobias-Fischer 