### PR TITLE
More than 3 points to calibrate kinect vs. robot

### DIFF
--- a/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.cpp
+++ b/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.cpp
@@ -2,9 +2,9 @@
 #include <vector>
 #include "AgentDetector.h"
 
-bool AgentDetector::clicked = false;
-float AgentDetector::clickX = 0;
-float AgentDetector::clickY = 0;
+clickType AgentDetector::clicked=idle;
+float AgentDetector::clickX=0.0F;
+float AgentDetector::clickY=0.0F;
 
 
 bool AgentDetector::showImageParser(string &mode, string &submode)
@@ -54,8 +54,6 @@ bool AgentDetector::configure(ResourceFinder &rf)
     partner = opc->addOrRetrieveEntity<Agent>(partner_default_name);
     partner->m_present = false;
     opc->commit(partner);
-//    opc->addOrRetrieveEntity<Action>("named");
-
 
     //Retrieve the calibration matrix from RFH
     string rfhName=rf.check("rfh",Value("referenceFrameHandler")).asString().c_str();
@@ -73,14 +71,12 @@ bool AgentDetector::configure(ResourceFinder &rf)
         cout<<"Waiting connection to RFH..."<<endl;
         Time::delay(1.0);
     }
-    isCalibrated = false;
-    isCalibrated = checkCalibration();
+    isCalibrated=checkCalibration();
 
     if(!isCalibrated){
         yWarning() << " ========================= KINECT NEED TO BE CALIBRATED ============================" ;
     }
 
-    pointsCount = 0;
     string clientName = name;
     clientName += "/kinect";
 
@@ -242,37 +238,25 @@ bool AgentDetector::checkCalibration()
 
     if (rfh.getOutputCount()>0)
     {
-        //Get the kinect2icub
-        Bottle bCmd;
-        bCmd.clear();
+        Bottle bCmd,reply;
         bCmd.addString("mat");
         bCmd.addString("kinect");
         bCmd.addString("icub");
+        rfh.write(bCmd,reply);
 
-        Bottle reply;
-        reply.clear();
-        rfh.write(bCmd, reply);
-        if (reply.get(0) == "nack")
+        if (reply.get(0)!="nack")
         {
-            //yWarning() <<"Transformation matrix not retrieved";
-            return false;
-        }
-        else
-        {
-            Bottle* bMat = reply.get(1).asList();
-            kinect2icub.resize(4,4);
-            for(int i=0; i<4; i++)
+            if (Bottle *bMat=reply.get(1).asList())
             {
-                for(int j=0; j<4; j++)
-                {
-                    kinect2icub(i,j)=bMat->get(4*i+j).asDouble();
-                }
+                kinect2icub.resize(4,4);
+                for (int i=0; i<4; i++)
+                    for (int j=0; j<4; j++)
+                        kinect2icub(i,j)=bMat->get(4*i+j).asDouble();
+                return isCalibrated=true;
             }
-            //yInfo()<<"Transformation matrix retrieved"<<endl<<kinect2icub.toString(3,3).c_str();
-            isCalibrated = true;
-            return true;
         }
     }
+
     return false;
 }
 
@@ -415,15 +399,15 @@ bool AgentDetector::updateModule()
     }
 
     //Send the players information to the OPC
-    bool localIsCalibrated = checkCalibration();
+    bool localIsCalibrated=checkCalibration();
 
     //Allow click calibration
     if (!localIsCalibrated)
     {
-        //yInfo() << " not calib";
-        if (AgentDetector::clicked)
+        if (AgentDetector::clicked==clicked_left)
         {
-            AgentDetector::clicked = false;
+            AgentDetector::clicked=idle;
+
             //Get the clicked point coordinate in Kinect space
             Vector clickedPoint(3);
             cout<<"Processing a click on ("<<AgentDetector::clickX<<" "<<AgentDetector::clickY<<") --> ";
@@ -433,9 +417,6 @@ bool AgentDetector::updateModule()
             Bottle bCond;
             Bottle bObject;
             Bottle bRTObject;
-
-            //(entity ==  object or entity == rtobject) && isPresent == 1. But OPC does not handle nested condition so
-            //(entity == object) && (isPresent == 1) || (entity == rtobject) && (isPresent == 1)
 
             bObject.addString(EFAA_OPC_ENTITY_TAG);
             bObject.addString("==");
@@ -450,57 +431,57 @@ bool AgentDetector::updateModule()
             bPresent.addString("==");
             bPresent.addInt(1);
 
-            bCond.addList() = bObject;
+            bCond.addList()=bObject;
             bCond.addString("&&");
-            bCond.addList() = bPresent;
+            bCond.addList()=bPresent;
             bCond.addString("||");
-            bCond.addList() = bRTObject;
+            bCond.addList()=bRTObject;
             bCond.addString("&&");
-            bCond.addList() = bPresent;
+            bCond.addList()=bPresent;
             opc->checkout();
-            opc->isVerbose = true;
-            list<Entity*> presentObjects = opc->Entities(bCond);
-            opc->isVerbose = false;
-            if (presentObjects.size() != 1)
+            opc->isVerbose=true;
+            list<Entity*> presentObjects=opc->Entities(bCond);
+            opc->isVerbose=false;
+            if (presentObjects.size()!=1)
             {
                 cout<<"There should be 1 and only 1 object on the table"<<endl;
             }
             else
             {
-                Object* o = (Object*) (presentObjects.front());
+                Object* o=(Object*)(presentObjects.front());
                 //Prepare the bottle to be sent to RFH
                 Bottle botRPH, botRPHRep;
                 botRPH.addString("add");
                 botRPH.addString("kinect");
-                Bottle &cooKinect = botRPH.addList();
+                Bottle &cooKinect=botRPH.addList();
                 cooKinect.addDouble(clickedPoint[0]);
                 cooKinect.addDouble(clickedPoint[1]);
                 cooKinect.addDouble(clickedPoint[2]);
 
-                Bottle &cooiCub = botRPH.addList();
+                Bottle &cooiCub=botRPH.addList();
                 cooiCub.addDouble(o->m_ego_position[0]);
                 cooiCub.addDouble(o->m_ego_position[1]);
                 cooiCub.addDouble(o->m_ego_position[2]);
                 rfh.write(botRPH,botRPHRep);
                 cout<<"Sent to RFH: "<<botRPH.toString().c_str()<<endl;
                 cout<<"Got from RFH: "<<botRPHRep.toString().c_str()<<endl;
-
-                pointsCount++;
-                if(pointsCount >= 3 )
-                {
-                    Bottle calibBottle, calibReply;
-                    calibBottle.addString("cal");
-                    calibBottle.addString("kinect");
-                    rfh.write(calibBottle,calibReply);
-                    cout<<"Calibrated ! "<<calibReply.toString().c_str()<<endl;
-
-                    calibBottle.clear();
-                    calibBottle.addString("save");
-                    rfh.write(calibBottle,calibReply);
-                    cout<<"Saved to file ! "<<calibReply.toString().c_str()<<endl;
-                    checkCalibration();
-                }
             }
+        }
+        else if (AgentDetector::clicked==clicked_right)
+        {
+            AgentDetector::clicked=idle;
+
+            Bottle calibBottle,calibReply;
+            calibBottle.addString("cal");
+            calibBottle.addString("kinect");
+            rfh.write(calibBottle,calibReply);
+            cout<<"Calibrated ! "<<calibReply.toString().c_str()<<endl;
+
+            calibBottle.clear();
+            calibBottle.addString("save");
+            rfh.write(calibBottle,calibReply);
+            cout<<"Saved to file ! "<<calibReply.toString().c_str()<<endl;
+            checkCalibration();
         }
     }
 
@@ -556,7 +537,6 @@ bool AgentDetector::updateModule()
                         playerName = getIdentity(*p);
                     }
 
-
                     //We interact with OPC only if the calibration is done
                     if (localIsCalibrated)
                     {
@@ -564,8 +544,7 @@ bool AgentDetector::updateModule()
                         opc->checkout();
                         partner = opc->addOrRetrieveEntity<Agent>(partner_default_name);
                         partner->m_present = true;
-                        //yInfo() << " is localIsCalibrated";
-                            
+
                         // reset the timing.
                         dTimingLastApparition = clock();
                         

--- a/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.h
+++ b/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.h
@@ -14,6 +14,11 @@ using namespace yarp::math;
 using namespace kinectWrapper;
 using namespace wysiwyd::wrdac;
 
+typedef enum {
+    idle,
+    clicked_left,
+    clicked_right } clickType;
+
 class AgentDetector: public RFModule
 {
 protected:
@@ -49,8 +54,8 @@ protected:
     bool isCalibrated;
     Matrix kinect2icub;
     Matrix icub2ir;
-    int pointsCount;
-    static bool clicked;
+    
+    static clickType clicked;
     static float clickX, clickY;
 
     //Agent Identity related
@@ -92,19 +97,21 @@ public:
 
     Vector getSkeletonPattern(Player p);
 
-    static void click_callback( int event, int x, int y, int flags, void* param ){
-        //IplImage* image = (IplImage*) param;
-
-        switch( event ){
-
-            case CV_EVENT_LBUTTONDOWN:
-                cout<<"Got a click."<<endl;
-                AgentDetector::clickX = (float)x;
-                AgentDetector::clickY = (float)y;
-                AgentDetector::clicked = true;
-                break;
-
-            default: break;
+    static void click_callback(int event, int x, int y, int flags, void* param)
+    {
+        switch (event)
+        {
+        case CV_EVENT_LBUTTONDOWN:
+            cout<<"Got a left-click."<<endl;
+            AgentDetector::clickX=(float)x;
+            AgentDetector::clickY=(float)y;
+            AgentDetector::clicked=clicked_left;
+            break;
+        case CV_EVENT_RBUTTONDOWN:
+            cout<<"Got a right-click."<<endl;
+            AgentDetector::clicked=clicked_right;
+            break;
         }
     }
 };
+

--- a/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.h
+++ b/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.h
@@ -55,6 +55,7 @@ protected:
     Matrix kinect2icub;
     Matrix icub2ir;
     
+    int pointsCnt;
     static clickType clicked;
     static float clickX, clickY;
 

--- a/main/src/modules/humanUnderstanding/agentDetector/agentDetector.xml
+++ b/main/src/modules/humanUnderstanding/agentDetector/agentDetector.xml
@@ -10,11 +10,10 @@
   <version>1.0</version>
 
   <description-long>
-    Module based on \ref kinectClient "Kinect Wrapper Client" that track and recognize people. This module receives information from the Kinect wrapper, performs facial identification and convert joints
-to the iCub referential.
+    Module based on \ref kinectClient "Kinect Wrapper Client" that track and recognize people.
+    This module receives information from the Kinect wrapper, performs facial identification and convert joints to the iCub referential.
 
-It requires the \ref kinectServer an OPC and RFH running.
-
+    It requires the \ref kinectServer an OPC and RFH running.
   </description-long>
 
   <arguments>


### PR DESCRIPTION
Following up a recent discussion with @Tobias-Fischer, I've just extended `agentDetector` to deal with more than 3 points to calibrate RGBD sensor frame alongside with the robot root frame.
This change aims to make the final calibration more robust against noise.

- **`left-click`** on the depth image :arrow_right: points pairs collection.
- **`right-click`** on the depth image :arrow_right: calibration starts.