### PR TITLE
AttentionSelector to deal with objects persistence 

### DIFF
--- a/main/src/libraries/wrdac/include/wrdac/knowledge/object.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/object.h
@@ -56,7 +56,7 @@ public:
     /**
     * Is the object present in the scene
     */          
-    bool              m_present;
+    double              m_present;
 
     /**
     * A measurement of the object saliency [0,1]

--- a/main/src/libraries/wrdac/src/bodypart.cpp
+++ b/main/src/libraries/wrdac/src/bodypart.cpp
@@ -30,7 +30,7 @@ Bodypart::Bodypart():Object()
     m_tactile_number = -1;
     m_kinStruct_instance = -1;
     m_part = "unknown";
-    m_present = true;
+    m_present = 1.0;
 }
 
 
@@ -41,7 +41,7 @@ Bodypart::Bodypart(const Bodypart &b):Object(b)
     this->m_tactile_number = b.m_tactile_number;
     this->m_kinStruct_instance = b.m_kinStruct_instance;
     this->m_part = b.m_part;
-    this->m_present = true;
+    this->m_present = 1.0;
 }
 
 Bottle Bodypart::asBottle()

--- a/main/src/libraries/wrdac/src/icubClient.cpp
+++ b/main/src/libraries/wrdac/src/icubClient.cpp
@@ -440,7 +440,7 @@ bool ICubClient::grasp(const string &oName, const Bottle &options)
     }
 
     Object *oTarget = dynamic_cast<Object*>(target);
-    if (!oTarget->m_present)
+    if (oTarget->m_present!=1.0)
     {
         cerr << "[iCubClient] Called grasp() on an unavailable entity: \"" << oName << "\"" << endl;
         return false;
@@ -483,7 +483,7 @@ bool ICubClient::release(const string &oLocation, const Bottle &options)
     }
 
     Object *oTarget = dynamic_cast<Object*>(target);
-    if (!oTarget->m_present)
+    if (oTarget->m_present!=1.0)
     {
         cerr << "[iCubClient] Called release() on an unavailable entity: \"" << oLocation << "\"" << endl;
         return false;
@@ -522,7 +522,7 @@ bool ICubClient::point(const string &oLocation, const Bottle &options)
     }
 
     Object *oTarget = dynamic_cast<Object*>(target);
-    if (!oTarget->m_present)
+    if (oTarget->m_present!=1.0)
     {
         cerr << "[iCubClient] Called point() on an unavailable entity: \"" << oLocation << "\"" << endl;
         return false;
@@ -555,7 +555,7 @@ bool ICubClient::look(const string &target)
     if (SubSystem_ARE *are = getARE())
     {
         if (Object *oTarget = dynamic_cast<Object*>(opc->getEntity(target)))
-            if (oTarget->m_present)
+            if (oTarget->m_present==1.0)
                 return are->look(oTarget->m_ego_position, yarp::os::Bottle() , oTarget->name());
 
         cerr << "[iCubClient] Called look() on an unavailable target: \"" << target << "\"" << endl;
@@ -778,7 +778,7 @@ list<Object*> ICubClient::getObjectsInRange()
     list<Entity*> allEntities = opc->EntitiesCache();
     for (list<Entity*>::iterator it = allEntities.begin(); it != allEntities.end(); it++)
     {
-        if ((*it)->isType(EFAA_OPC_ENTITY_OBJECT) && (dynamic_cast<Object*>(*it))->m_present)
+        if ((*it)->isType(EFAA_OPC_ENTITY_OBJECT) && (dynamic_cast<Object*>(*it))->m_present==1.0)
         {
             Vector itemPosition = this->icubAgent->getSelfRelativePosition((dynamic_cast<Object*>(*it))->m_ego_position);
 

--- a/main/src/libraries/wrdac/src/object.cpp
+++ b/main/src/libraries/wrdac/src/object.cpp
@@ -34,7 +34,7 @@ Object::Object():Entity()
     m_dimensions.resize(3,0.1);
     m_color.resize(3,255.0);
     m_saliency = 0.0;
-    m_present = false;
+    m_present = 0.0;
     
     // by default, place object 25cm in front of the robot
     // to avoid collisions when pointing to an object
@@ -119,10 +119,7 @@ Bottle Object::asBottle()
 
     //Present
     bSub.addString(EFAA_OPC_OBJECT_PRESENT_TAG);
-    if (this->m_present)
-        bSub.addInt(1);
-    else
-        bSub.addInt(0);
+    bSub.addDouble(this->m_present);
     b.addList() = bSub;
 
     return b;
@@ -163,7 +160,7 @@ bool Object::fromBottle(Bottle b)
     m_color[1] = b.find(EFAA_OPC_OBJECT_GUI_COLOR_G).asDouble();
     m_color[2] = b.find(EFAA_OPC_OBJECT_GUI_COLOR_B).asDouble();
     m_saliency = b.find(EFAA_OPC_OBJECT_SALIENCY).asDouble();
-    m_present = (b.find(EFAA_OPC_OBJECT_PRESENT_TAG).asInt() == 1);
+    m_present = b.find(EFAA_OPC_OBJECT_PRESENT_TAG).asDouble();
     return true;
 }
 

--- a/main/src/libraries/wrdac/src/opcEars.cpp
+++ b/main/src/libraries/wrdac/src/opcEars.cpp
@@ -157,7 +157,7 @@ Bottle opcEars::insertEntity(Entity *A)
         Object OA;
         OA.fromBottle(bA);
 
-        if (OA.m_present)
+        if (OA.m_present==1.0)
             osEntity << " , TRUE , '{ ";
         else
             osEntity << " , FALSE , '{ ";
@@ -187,7 +187,7 @@ Bottle opcEars::insertEntity(Entity *A)
         AgA.fromBottle(bA);
         bool fBelief = false;
 
-        if (AgA.m_present)
+        if (AgA.m_present==1.0)
             osEntity << " , TRUE , '{ ";
         else
             osEntity << " , FALSE , '{ ";
@@ -239,7 +239,7 @@ Bottle opcEars::insertEntity(Entity *A)
         RTObject RTA;
         RTA.fromBottle(bA);
 
-        if (RTA.m_present)
+        if (RTA.m_present==1.0)
             osEntity << " , TRUE , '{ ";
         else
             osEntity << " , FALSE , '{ ";
@@ -828,7 +828,9 @@ Bottle opcEars::getDiffObject(Object *AgA, Object *AgB)
     {
         bTemp.clear();
         bTemp.addString(EFAA_OPC_OBJECT_PRESENT_TAG);
-        bTemp.addInt(AgB->m_present - AgA->m_present);
+        int tmpA=AgA->m_present==1.0?1:0;
+        int tmpB=AgB->m_present==1.0?1:0;
+        bTemp.addInt(tmpB-tmpA);
         bOutput.addList() = bTemp;
     }
 

--- a/main/src/libraries/wrdac/src/rtObject.cpp
+++ b/main/src/libraries/wrdac/src/rtObject.cpp
@@ -29,7 +29,7 @@ RTObject::RTObject():Object()
 {    
     m_entity_type = EFAA_OPC_ENTITY_RTOBJECT;
     m_rt_position.resize(3,0.0);
-    m_present = true;
+    m_present = 1.0;
 }
 
 
@@ -37,7 +37,7 @@ RTObject::RTObject(const RTObject &b):Object(b)
 {
     this->m_entity_type = b.m_entity_type;
     this->m_rt_position = b.m_rt_position;
-    this->m_present = true;
+    this->m_present = 1.0;
 }
 
 Bottle RTObject::asBottle()

--- a/main/src/modules/abm/abmReasoning/src/interlocutorABM.cpp
+++ b/main/src/modules/abm/abmReasoning/src/interlocutorABM.cpp
@@ -775,7 +775,7 @@ Bottle abmReasoning::findAllActions(int from)
                 LOCATION->m_dimensions[0] = 0.04;
                 LOCATION->m_dimensions[1] = 0.04;
                 LOCATION->m_dimensions[2] = 0.08;
-                LOCATION->m_present = 1;
+                LOCATION->m_present = 1.0;
                 LOCATION->m_color[0] = 100;
                 LOCATION->m_color[1] = 255;
                 LOCATION->m_color[2] = 0;
@@ -835,7 +835,7 @@ Bottle abmReasoning::findAllActions(int from)
                 LOCATION->m_ego_position[0] = END.first;
                 LOCATION->m_ego_position[1] = END.second;
                 LOCATION->m_ego_position[2] = 0.01;
-                LOCATION->m_present = 1;
+                LOCATION->m_present = 1.0;
                 LOCATION->m_color[0] = 100;
                 LOCATION->m_color[1] = 255;
                 LOCATION->m_color[2] = 0;
@@ -847,7 +847,7 @@ Bottle abmReasoning::findAllActions(int from)
     {
         string  sObject = "dream...";
         RTObject* LOCATION = mentalOPC->addOrRetrieveEntity<RTObject>(sObject);
-        LOCATION->m_present = 0;
+        LOCATION->m_present = 0.0;
         mentalOPC->commit();
     }
     yInfo() << "\t";
@@ -949,7 +949,7 @@ Bottle abmReasoning::findAllActionsV2(int from)
                     LOCATION->m_dimensions[0] = 0.04;
                     LOCATION->m_dimensions[1] = 0.04;
                     LOCATION->m_dimensions[2] = 0.08;
-                    LOCATION->m_present = 1;
+                    LOCATION->m_present = 1.0;
                     LOCATION->m_color[0] = 100;
                     LOCATION->m_color[1] = 255;
                     LOCATION->m_color[2] = 0;
@@ -984,7 +984,7 @@ Bottle abmReasoning::findAllActionsV2(int from)
                     LOCATION->m_ego_position[0] = END.first;
                     LOCATION->m_ego_position[1] = END.second;
                     LOCATION->m_ego_position[2] = 0.01;
-                    LOCATION->m_present = 1;
+                    LOCATION->m_present = 1.0;
                     LOCATION->m_color[0] = 100;
                     LOCATION->m_color[1] = 255;
                     LOCATION->m_color[2] = 0;
@@ -997,7 +997,7 @@ Bottle abmReasoning::findAllActionsV2(int from)
     {
         string  sObject = "dream...";
         RTObject* LOCATION = mentalOPC->addOrRetrieveEntity<RTObject>(sObject);
-        LOCATION->m_present = 0;
+        LOCATION->m_present = 0.0;
         mentalOPC->commit();
     }
     yInfo() << "\t";
@@ -2967,7 +2967,7 @@ Bottle  abmReasoning::askWordKnowledge(Bottle bInput)
         {
             Object o;
             o.fromBottle((*itE)->asBottle());
-            if (o.m_present)
+            if (o.m_present==1.0)
             {
                 vContext.push_back(o.name());
             }

--- a/main/src/modules/abm/abmReasoning/src/knowledgeRelated.cpp
+++ b/main/src/modules/abm/abmReasoning/src/knowledgeRelated.cpp
@@ -1445,7 +1445,7 @@ Bottle abmReasoning::updateKnownLocations()
                             LOCATION->m_dimensions[1] = sqrt(VP1)*abmReasoningFunction::FACTOR_LOCATION;
                             LOCATION->m_dimensions[2] = abmReasoningFunction::size_location * 2;
                             LOCATION->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
-                            LOCATION->m_present = 1;
+                            LOCATION->m_present = 1.0;
                             LOCATION->m_color[0] = colorR / 2;
                             LOCATION->m_color[1] = colorG / 2;
                             LOCATION->m_color[2] = colorB / 2;
@@ -1457,15 +1457,15 @@ Bottle abmReasoning::updateKnownLocations()
                             LOCATION_LARGE->m_dimensions[0] = sqrt(VP2) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                             LOCATION_LARGE->m_dimensions[1] = sqrt(VP1) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                             LOCATION_LARGE->m_dimensions[2] = abmReasoningFunction::size_location;
-                            LOCATION_LARGE->m_present = 1;
+                            LOCATION_LARGE->m_present = 1.0;
                             LOCATION_LARGE->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
                             LOCATION_LARGE->m_color[0] = colorR;
                             LOCATION_LARGE->m_color[1] = colorG;
                             LOCATION_LARGE->m_color[2] = colorB;
 
                             iAdded++;
-                            LOCATION->m_present = 1;
-                            LOCATION_LARGE->m_present = 0;
+                            LOCATION->m_present = 1.0;
+                            LOCATION_LARGE->m_present = 0.0;
                             realOPC->commit();
                         }
 
@@ -1480,7 +1480,7 @@ Bottle abmReasoning::updateKnownLocations()
                             LOCATION->m_dimensions[1] = sqrt(VP1)*abmReasoningFunction::FACTOR_LOCATION;
                             LOCATION->m_dimensions[2] = abmReasoningFunction::size_location * 2;
                             LOCATION->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
-                            LOCATION->m_present = 1;
+                            LOCATION->m_present = 1.0;
                             LOCATION->m_color[0] = colorR / 2;
                             LOCATION->m_color[1] = colorG / 2;
                             LOCATION->m_color[2] = colorB / 2;
@@ -1492,15 +1492,15 @@ Bottle abmReasoning::updateKnownLocations()
                             LOCATION_LARGE->m_dimensions[0] = sqrt(VP2) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                             LOCATION_LARGE->m_dimensions[1] = sqrt(VP1) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                             LOCATION_LARGE->m_dimensions[2] = abmReasoningFunction::size_location;
-                            LOCATION_LARGE->m_present = 1;
+                            LOCATION_LARGE->m_present = 1.0;
                             LOCATION_LARGE->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
                             LOCATION_LARGE->m_color[0] = colorR;
                             LOCATION_LARGE->m_color[1] = colorG;
                             LOCATION_LARGE->m_color[2] = colorB;
 
                             iAdded++;
-                            LOCATION->m_present = 1;
-                            LOCATION_LARGE->m_present = 0;
+                            LOCATION->m_present = 1.0;
+                            LOCATION_LARGE->m_present = 0.0;
                         }
                     }
                 }
@@ -1580,7 +1580,7 @@ Bottle abmReasoning::updateLocation(string sLocation)
                     LOCATION->m_dimensions[0] = sqrt(VP2)*abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION->m_dimensions[1] = sqrt(VP1)*abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION->m_dimensions[2] = 0.04;
-                    LOCATION->m_present = 1;
+                    LOCATION->m_present = 1.0;
                     LOCATION->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
                     LOCATION->m_color[0] = colorR / 2;
                     LOCATION->m_color[1] = colorG / 2;
@@ -1593,7 +1593,7 @@ Bottle abmReasoning::updateLocation(string sLocation)
                     LOCATION_LARGE->m_dimensions[0] = sqrt(VP2) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION_LARGE->m_dimensions[1] = sqrt(VP1) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION_LARGE->m_dimensions[2] = 0.02;
-                    LOCATION_LARGE->m_present = 1;
+                    LOCATION_LARGE->m_present = 1.0;
                     LOCATION_LARGE->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
                     LOCATION_LARGE->m_color[0] = colorR;
                     LOCATION_LARGE->m_color[1] = colorG;
@@ -1614,7 +1614,7 @@ Bottle abmReasoning::updateLocation(string sLocation)
                     LOCATION->m_dimensions[0] = sqrt(VP2)*abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION->m_dimensions[1] = sqrt(VP1)*abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION->m_dimensions[2] = 0.04;
-                    LOCATION->m_present = 1;
+                    LOCATION->m_present = 1.0;
                     LOCATION->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
                     LOCATION->m_color[0] = abmReasoningFunction::color_loc_R / 2;
                     LOCATION->m_color[1] = abmReasoningFunction::color_loc_G / 2;
@@ -1627,7 +1627,7 @@ Bottle abmReasoning::updateLocation(string sLocation)
                     LOCATION_LARGE->m_dimensions[0] = sqrt(VP2) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION_LARGE->m_dimensions[1] = sqrt(VP1) * 2 * abmReasoningFunction::FACTOR_LOCATION;
                     LOCATION_LARGE->m_dimensions[2] = 0.02;
-                    LOCATION_LARGE->m_present = 1;
+                    LOCATION_LARGE->m_present = 1.0;
                     LOCATION_LARGE->m_ego_orientation[2] = sin(Vect2.second / Vect2.first)*180. / PI;
                     LOCATION_LARGE->m_color[0] = colorR;
                     LOCATION_LARGE->m_color[1] = colorG;
@@ -1676,19 +1676,19 @@ Bottle abmReasoning::DeleteKnownLocations()
                 if (realOPC->isConnected())
                 {
                     Object* LOCATION = realOPC->addOrRetrieveEntity<Object>(sLoc);
-                    LOCATION->m_present = 0;
+                    LOCATION->m_present = 0.0;
 
                     Object* LOCATION_LARGE = realOPC->addOrRetrieveEntity<Object>(large);
-                    LOCATION_LARGE->m_present = 0;
+                    LOCATION_LARGE->m_present = 0.0;
                 }
 
                 if (mentalOPC->isConnected())
                 {
                     Object* LOCATION = mentalOPC->addOrRetrieveEntity<Object>(sLoc);
-                    LOCATION->m_present = 0;
+                    LOCATION->m_present = 0.0;
 
                     Object* LOCATION_LARGE = mentalOPC->addOrRetrieveEntity<Object>(large);
-                    LOCATION_LARGE->m_present = 0;
+                    LOCATION_LARGE->m_present = 0.0;
                 }
             }
         }

--- a/main/src/modules/abm/abmReasoning/src/macroFunction.cpp
+++ b/main/src/modules/abm/abmReasoning/src/macroFunction.cpp
@@ -2031,17 +2031,17 @@ Bottle abmReasoning::imagineOPC(int Id)
     {
         if ((*it_E)->entity_type() == EFAA_OPC_ENTITY_OBJECT)   {
             Object *Ob = dynamic_cast<Object*>(*it_E);
-            Ob->m_present = 0;
+            Ob->m_present = 0.0;
         }
 
         if ((*it_E)->entity_type() == EFAA_OPC_ENTITY_AGENT)    {
             Agent *Ag = dynamic_cast<Agent*>(*it_E);
-            Ag->m_present = 0;
+            Ag->m_present = 0.0;
         }
 
         if ((*it_E)->entity_type() == EFAA_OPC_ENTITY_RTOBJECT) {
             RTObject *Rt = dynamic_cast<RTObject*>(*it_E);
-            Rt->m_present = 0;
+            Rt->m_present = 0.0;
         }
     }
     mentalOPC->commit();
@@ -2051,7 +2051,7 @@ Bottle abmReasoning::imagineOPC(int Id)
 
     // ADD Agent iCub
     Agent *icub = mentalOPC->addEntity<Agent>("icub");
-    icub->m_present = true;
+    icub->m_present = 1.0;
     mentalOPC->commit(icub);
 
     // Get the id of the RTO present
@@ -2083,7 +2083,7 @@ Bottle abmReasoning::imagineOPC(int Id)
 
         RTOtemp->m_ego_position[0] = pCoordinate.first;
         RTOtemp->m_ego_position[1] = pCoordinate.second;
-        RTOtemp->m_present = bPresence;
+        RTOtemp->m_present = (bPresence?1.0:0.0);
         RTOtemp->m_color[0] = get<0>(tColor);
         RTOtemp->m_color[1] = get<1>(tColor);
         RTOtemp->m_color[2] = get<2>(tColor);

--- a/main/src/modules/abm/autobiographicalMemory/src/autobiographicalMemory.cpp
+++ b/main/src/modules/abm/autobiographicalMemory/src/autobiographicalMemory.cpp
@@ -1382,7 +1382,7 @@ TempAgent->m_color.push_back(*it);
 //TempAgent->m_color[1] = get<1>(colorAgent);
 //TempAgent->m_color[2] = get<2>(colorAgent);
 }
-TempAgent->m_present = false;
+TempAgent->m_present = 0.0;
 
 opcWorld->commit(TempAgent);
 incrAgent++;
@@ -1413,12 +1413,12 @@ RTObject *RTO = opcWorld->addEntity<RTObject>(sName.c_str());
 //RTO->m_color[0] = get<0>(colorRto);
 //RTO->m_color[1] = get<1>(colorRto);
 //RTO->m_color[2] = get<2>(colorRto);
-//RTO->m_present = false;
+//RTO->m_present = 0.0;
 RTO->m_color.clear();
 for (vector<int>::iterator it = colorRto.begin(); it != colorRto.end(); it++){
 RTO->m_color.push_back(*it);
 }
-RTO->m_present = false;
+RTO->m_present = 0.0;
 
 opcWorld->commit(RTO);
 incrRTO++;
@@ -1484,7 +1484,7 @@ for (vector<double>::iterator it = orientationObject.begin(); it != orientationO
 TempObj->m_color.push_back(*it);
 }
 
-TempObj->m_present = false;
+TempObj->m_present = 0.0;
 
 opcWorld->commit(TempObj);
 incrObject++;

--- a/main/src/modules/adaptiveLayer/src/adaptiveLayer.cpp
+++ b/main/src/modules/adaptiveLayer/src/adaptiveLayer.cpp
@@ -56,7 +56,7 @@ bool AdaptiveLayer::handleGesture()
     bool gotSignal = false;
     string humanName = "partner";
     Agent* partner = dynamic_cast<Agent*>(iCub->opc->getEntity(humanName));
-    if (partner->m_present)
+    if (partner->m_present==1.0)
     {
 
         //Check if the human did a particular gesture
@@ -434,7 +434,7 @@ void AdaptiveLayer::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 string name = agentList->get(d).asString().c_str();
                 Agent* agent = iCub->opc->addOrRetrieveEntity<Agent>(name);
-                agent->m_present = false;
+                agent->m_present = 0.0;
                 iCub->opc->commit(agent);
             }
         }
@@ -446,7 +446,7 @@ void AdaptiveLayer::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 string name = objectList->get(d).asString().c_str();
                 Object* o = iCub->opc->addOrRetrieveEntity<Object>(name);
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }
@@ -458,7 +458,7 @@ void AdaptiveLayer::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 string name = rtobjectList->get(d).asString().c_str();
                 RTObject* o = iCub->opc->addOrRetrieveEntity<RTObject>(name);
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }

--- a/main/src/modules/attentionRelated/attentionSelector/src/attentionSelector.cpp
+++ b/main/src/modules/attentionRelated/attentionSelector/src/attentionSelector.cpp
@@ -260,7 +260,7 @@ bool attentionSelectorModule::updateModule()
             are->track(newTarget);
     }
     else if (trackedObject != "none")
-    {        
+    {
         if (Object *oTracked=dynamic_cast<Object*>(opc->getEntity(trackedObject)))
         {
             yInfo() << "Tracking locked on object " << trackedObject << ".";
@@ -320,13 +320,13 @@ void attentionSelectorModule::exploring()
             timeLastSwitch = Time::now();
         }
     }
-    
+
     if (trackedObject!="none")
     {
         Object *obj=dynamic_cast<Object*>(opc->getEntity(trackedObject));
         if (obj->m_present!=1.0)
         {
-            are->look(obj->m_ego_position,Bottle("wait")); 
+            are->look(obj->m_ego_position,Bottle("wait"));
             obj=dynamic_cast<Object*>(opc->getEntity(obj->name(),true));
             if (obj->m_present!=1.0)
             {

--- a/main/src/modules/attentionRelated/pasar/src/pasar.cpp
+++ b/main/src/modules/attentionRelated/pasar/src/pasar.cpp
@@ -331,19 +331,19 @@ void PasarModule::saliencyTopDown() {
 
             // If the object is absent:
             // if the lastTimeSeen was more than a threshold, the object dissapeared
-            disappeared = (now - it.second.lastTimeSeen > dthresholdDisappear) && (!it.second.o.m_present) && it.second.present;
+            disappeared = (now - it.second.lastTimeSeen > dthresholdDisappear) && (it.second.o.m_present!=1.0) && it.second.present;
             if (disappeared){
                 cout << "DISAPPEARED since: " << now - it.second.lastTimeSeen << endl;
             }
 
             // If the object is present:
             // if the lastTimeSeen was more than a threshold, the object appeared
-            appeared = (now - it.second.lastTimeSeen > dthresholdAppear) && (it.second.o.m_present) && !it.second.present;
+            appeared = (now - it.second.lastTimeSeen > dthresholdAppear) && (it.second.o.m_present==1.0) && !it.second.present;
             if (appeared){
                 cout << "APPEARED since: " << now - it.second.lastTimeSeen << endl;
             }
 
-            if (it.second.o.m_present) it.second.lastTimeSeen = now;
+            if (it.second.o.m_present==1.0) it.second.lastTimeSeen = now;
 
             //instantaneous speed/acceleration
             Vector lastPos = presentObjectsLastStep[it.first].o.m_ego_position;
@@ -598,7 +598,7 @@ bool PasarModule::saliencyWaving()
     double dAccelRight;
     bool wavingNow = false;
 
-    if (!ag || !ag->m_present)
+    if (!ag || (ag->m_present!=1.0))
     {
         presentRightHand.first = presentRightHand.second;
         presentLeftHand.first = presentLeftHand.second;
@@ -751,9 +751,8 @@ void PasarModule::initializeMapTiming()
             {
                 Object * ob = dynamic_cast<Object*>(entity);
                 OPCEntities[entity->opc_id()].o = *ob;
-                OPCEntities[entity->opc_id()].lastTimeSeen = ob->m_present ? now : now - 10;
-                OPCEntities[entity->opc_id()].present = ob->m_present;
-
+                OPCEntities[entity->opc_id()].lastTimeSeen = (ob->m_present==1.0) ? now : now - 10;
+                OPCEntities[entity->opc_id()].present = (ob->m_present==1.0);
             }
         }
     }

--- a/main/src/modules/attentionRelated/proactiveTagging/src/helpers.cpp
+++ b/main/src/modules/attentionRelated/proactiveTagging/src/helpers.cpp
@@ -67,7 +67,7 @@ void proactiveTagging::configureOPC(yarp::os::ResourceFinder &rf)
                 std::string name = objectList->get(d).asString().c_str();
                 wysiwyd::wrdac::Object* o = iCub->opc->addOrRetrieveEntity<Object>(name);
                 yInfo() << " [configureOPC] object " << o->name() << "added" ;
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }
@@ -86,7 +86,7 @@ void proactiveTagging::configureOPC(yarp::os::ResourceFinder &rf)
                 std::string name = objectList->get(d).asString().c_str();
                 wysiwyd::wrdac::Object* o = iCub->opc->addEntity<Object>(name);
                 yInfo() << " [configureOPC] object " << o->name() << "added" ;
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }
@@ -103,7 +103,7 @@ void proactiveTagging::configureOPC(yarp::os::ResourceFinder &rf)
                 std::string name = bodyPartList->get(d).asString().c_str();
                 wysiwyd::wrdac::Bodypart* o = iCub->opc->addEntity<Bodypart>(name);
                 yInfo() << " [configureOPC] Bodypart " << o->name() << "added" ;
-                o->m_present = false;
+                o->m_present = 0.0;
                 //apply the joint number if available. protect for the loop because using d from bodyPartList. should be same number of element between bodyPartList and bodyPartJointList
                 if(d < bodyPartJointList->size()){
                     o->m_joint_number = bodyPartJointList->get(d).asInt();

--- a/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.cpp
+++ b/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.cpp
@@ -53,7 +53,7 @@ bool AgentDetector::configure(ResourceFinder &rf)
     }
     opc->checkout();
     partner = opc->addOrRetrieveEntity<Agent>(partner_default_name);
-    partner->m_present = false;
+    partner->m_present = 0.0;
     opc->commit(partner);
 
     //Retrieve the calibration matrix from RFH
@@ -500,9 +500,9 @@ bool AgentDetector::updateModule()
         //Clear the previous agents
         //for(map<int, Agent*>::iterator pA=identities.begin(); pA!=identities.end() ; pA++)
         //{
-        //    pA->second->m_present = false;
+        //    pA->second->m_present = 0.0;
         //}  
-        //partner->m_present = false;
+        //partner->m_present = 0.0;
 
         // check if last apparition was more than dThreshlodDisaparition ago
 
@@ -551,7 +551,7 @@ bool AgentDetector::updateModule()
                         //Retrieve this player in OPC or create if does not exist
                         opc->checkout();
                         partner = opc->addOrRetrieveEntity<Agent>(partner_default_name);
-                        partner->m_present = true;
+                        partner->m_present = 1.0;
 
                         // reset the timing.
                         dTimingLastApparition = clock();
@@ -566,7 +566,7 @@ bool AgentDetector::updateModule()
                                 yError() << "SHIT specificAgent";
                             } else {
                                 identities[p->ID] = specificAgent->name();
-                                specificAgent->m_present = true;
+                                specificAgent->m_present = 1.0;
                                 yInfo() << " specific agent is commited";
                                 opc->commit(specificAgent);
                                 yInfo() << " specific agent is commited done";
@@ -623,7 +623,7 @@ bool AgentDetector::updateModule()
             {
                 opc->checkout();
                 partner = opc->addOrRetrieveEntity<Agent>(partner_default_name);
-                partner->m_present = false;
+                partner->m_present = 0.0;
                 opc->commit(partner);
             }
             else

--- a/main/src/modules/navigationRelated/interpersonalDistanceRegulator/interpersonalDistanceRegulator.cpp
+++ b/main/src/modules/navigationRelated/interpersonalDistanceRegulator/interpersonalDistanceRegulator.cpp
@@ -44,7 +44,7 @@ bool InterpersonalDistanceRegulator::updateModule()
     {
         partner = opc->addOrRetrieveEntity<Agent>("partner");
 
-        if (partner->m_present)
+        if (partner->m_present==1.0)
         {
             yarp::sig::Vector p = partner->m_ego_position;
             double linearSpeed = 0.0;

--- a/main/src/modules/opcRelated/opcInspector/src/opcInspector.cpp
+++ b/main/src/modules/opcRelated/opcInspector/src/opcInspector.cpp
@@ -247,12 +247,12 @@ bool OpcInspector::respond(const yarp::os::Bottle& command, yarp::os::Bottle& re
         }
         if( key2 == "show")
         {
-            objPtr->m_present = true;
+            objPtr->m_present = 1.0;
         opc->commit(objPtr);
         }
         if( key2 == "hide")
         {
-            objPtr->m_present = false;
+            objPtr->m_present = 0.0;
         opc->commit(objPtr);
         }
     }

--- a/main/src/modules/opcRelated/opcManager/src/opcManager.cpp
+++ b/main/src/modules/opcRelated/opcManager/src/opcManager.cpp
@@ -448,17 +448,17 @@ Bottle opcManager::synchoniseOPCs()
     {
         if ((*it_E)->entity_type() == EFAA_OPC_ENTITY_OBJECT)   {
             Object *Ob = dynamic_cast<Object*>(*it_E);
-            Ob->m_present = 0;
+            Ob->m_present = 0.0;
         }
 
         if ((*it_E)->entity_type() == EFAA_OPC_ENTITY_AGENT)    {
             Agent *Ag = dynamic_cast<Agent*>(*it_E);
-            Ag->m_present = 0;
+            Ag->m_present = 0.0;
         }
 
         if ((*it_E)->entity_type() == EFAA_OPC_ENTITY_RTOBJECT) {
             RTObject *Rt = dynamic_cast<RTObject*>(*it_E);
-            Rt->m_present = 0;
+            Rt->m_present = 0.0;
         }
     }
 

--- a/main/src/modules/perspectiveTaking/src/perspective_taking_meta/perspective_taking/src/opc_to_tf.cpp
+++ b/main/src/modules/perspectiveTaking/src/perspective_taking_meta/perspective_taking/src/opc_to_tf.cpp
@@ -29,7 +29,7 @@ void updateObjectsCallback(const ros::TimerEvent&) {
     for(const auto& entity:entities) {
         if(entity->isType("object")) {
             if (auto obj=dynamic_cast<wysiwyd::wrdac::Object*>(entity)) {
-                if(obj->m_present && obj->name()!="partner") {
+                if((obj->m_present==1.0) && obj->name()!="partner") {
                     // draw object in visualizer
                     auto obj_name = obj->name();
                     auto obj_pos_yarp = obj->m_ego_position;

--- a/main/src/modules/reactableRelated/reactable2opc/oscThread.cpp
+++ b/main/src/modules/reactableRelated/reactable2opc/oscThread.cpp
@@ -98,7 +98,7 @@ void OscThread::ProcessMessage( const osc::ReceivedMessage& m,
                 o->m_dimensions[1] = dimy;
                 o->m_dimensions[2] = 0.01;
 
-                o->m_present = true;
+                o->m_present = 1.0;
                 o->m_ego_orientation[0] = 0.0;
                 o->m_ego_orientation[1] = 0.0;
                 o->m_ego_orientation[2] = 0.0;//tobj->getAngle();
@@ -122,7 +122,7 @@ void OscThread::ProcessMessage( const osc::ReceivedMessage& m,
                 cout<<"Removing object"<<endl;
                 RTObject *o = dynamic_cast<RTObject*>(opc->getEntity(name));
                 if(o) {
-                    o->m_present = false;
+                    o->m_present = 0.0;
                     //opc->isVerbose = true;
                     opc->commit(o);
                     //opc->isVerbose = false;

--- a/main/src/modules/reactableRelated/reactable2opc/rt2objCol.cpp
+++ b/main/src/modules/reactableRelated/reactable2opc/rt2objCol.cpp
@@ -116,7 +116,7 @@ void Reactable2OPC::loadObjectsDatabase(ResourceFinder& rf)
         o->m_color[1] = bColor->get(1).asDouble();
         o->m_color[2] = bColor->get(2).asDouble();
 
-        o->m_present = false;
+        o->m_present = 0.0;
         w->commit(o);
         //cout<<o->toString()<<endl;
     }
@@ -231,7 +231,7 @@ void Reactable2OPC::addTuioObject(TuioObject *tobj) {
         o->m_ego_position[2] = icubPos[2] + idOffsets[tobj->getSymbolID()][2];
     }
 
-    o->m_present = true;
+    o->m_present = 1.0;
     o->m_ego_orientation[0] = 0.0;
     o->m_ego_orientation[1] = 0.0;
     o->m_ego_orientation[2] = tobj->getAngle();
@@ -262,7 +262,7 @@ void Reactable2OPC::removeTuioObject(TuioObject *tobj) {
     string objectName = idMap[tobj->getSymbolID()];
     RTObject *o = dynamic_cast<RTObject*>(w->getEntity(objectName));
     if(o) {
-        o->m_present = false;
+        o->m_present = 0.0;
         w->commit(o);
     }
 }
@@ -299,7 +299,7 @@ void Reactable2OPC::addTuioCursor(TuioCursor *tcur) {
         o->m_ego_position[2] = icubPos[2];
     }
 
-    o->m_present = true;
+    o->m_present = 1.0;
     o->m_ego_orientation[0] = 0.0;
     o->m_ego_orientation[1] = 0.0;
     o->m_ego_orientation[2] = 0.0;
@@ -328,7 +328,7 @@ void Reactable2OPC::removeTuioCursor(TuioCursor *tcur) {
     curName<<"cursor_"<<tcur->getCursorID();
     RTObject *o = dynamic_cast<RTObject*>(w->getEntity(curName.str()));
     if(o) {
-        o->m_present = false;
+        o->m_present = 0.0;
         w->commit(o);
     }
 }

--- a/main/src/modules/reactiveLayer/behaviorManager/src/pointingOrder.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/pointingOrder.cpp
@@ -50,7 +50,7 @@ bool PointingOrder::handlePoint(string type, string target)
             {
                 yInfo() << "I already knew that the object was in the opc: " << sName;
                 Object* o = dynamic_cast<Object*>(entity);
-                if(o && o->m_present) {
+                if(o && (o->m_present==1)) {
                     //pointRPC=true;
                     yInfo() << "I'd like to point " << e_name;// <<endl;
                     Object* obj1 = iCub->opc->addOrRetrieveEntity<Object>(e_name);
@@ -93,7 +93,7 @@ bool PointingOrder::handleSearch(string type, string target)
             {
                 Object* o = dynamic_cast<Object*>(entity);
                 yInfo() << "I found the entity in the opc: " << sName;
-                if(o && o->m_present) {
+                if(o && (o->m_present==1)) {
                     //searchList.pop_back();
                     // return, so "if(tagRPC)" ... is never executed
                     return true;

--- a/main/src/modules/reactiveLayer/behaviorManager/src/reactions.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/reactions.cpp
@@ -12,7 +12,7 @@ void Reactions::run(Bottle args/*=Bottle()*/) {
 
     Object* touchLocation = dynamic_cast<Object*>(iCub->opc->getEntity("touchLocation"));
     iCub->opc->update(touchLocation);
-    touchLocation->m_present = true;
+    touchLocation->m_present = 1.0;
     iCub->opc->commit(touchLocation);
 
     iCub->say("Wow");

--- a/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
@@ -158,7 +158,7 @@ Bottle OpcSensation::handleEntities()
             {
                 // yInfo() << "I found an unknown entity: " << sName;
                 Object* o = dynamic_cast<Object*>(entity);
-                if(o && o->m_present) {
+                if(o && (o->m_present==1.0)) {
                     unknown_obj = true;
                     //Output is a list of objects entity + objects name [the arguments for tagging]
                     // o->m_saliency = unknownObjectSaliency;
@@ -183,7 +183,7 @@ Bottle OpcSensation::handleEntities()
         else if (sNameCut == "partner" && entity->entity_type() == "agent") {
             yInfo() << "I found an unknown partner: " << sName;
             Agent* a = dynamic_cast<Agent*>(entity);
-            if(a && a->m_present) {
+            if(a && (a->m_present==1.0)) {
                 unknown_obj = true;
                 //Output is a list of objects entity + objects name [the arguments for tagging]
                 // o->m_saliency = unknownObjectSaliency;

--- a/main/src/modules/reactiveLayerEFAA/src/reactiveLayer.cpp
+++ b/main/src/modules/reactiveLayerEFAA/src/reactiveLayer.cpp
@@ -229,7 +229,7 @@ bool ReactiveLayer::handleTactile()
         //Look at the place where it has been touched
         Object* touchLocation = dynamic_cast<Object*>(iCub->opc->getEntity("touchLocation"));
         iCub->opc->update(touchLocation);
-        touchLocation->m_present = true;
+        touchLocation->m_present = 1.0;
         iCub->opc->commit(touchLocation);
 
         iCub->look("touchLocation");//r.complement_place().c_str());
@@ -257,7 +257,7 @@ bool ReactiveLayer::handleTactile()
         iCub->commitAgent();
 
         iCub->opc->removeRelation(r);
-        touchLocation->m_present = false;
+        touchLocation->m_present = 0.0;
         iCub->opc->commit(touchLocation);
         iCub->look("partner");
         iCub->lookAround();
@@ -283,7 +283,7 @@ bool ReactiveLayer::handleSalutation(bool& someoneIsPresent)
         Agent* currentAgent = dynamic_cast<Agent*>(*currentAgentIt);
 
 
-        if (currentAgent->name() != "icub" && currentAgent->m_present)
+        if (currentAgent->name() != "icub" && (currentAgent->m_present==1.0))
         {
             someoneIsPresent = true;
             string currentPartner = currentAgent->name();
@@ -378,7 +378,7 @@ void ReactiveLayer::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 string name = agentList->get(d).asString().c_str();
                 Agent* agent = iCub->opc->addOrRetrieveAgent(name);
-                agent->m_present = false;
+                agent->m_present = 0.0;
                 iCub->opc->commit(agent);
             }
         }
@@ -390,7 +390,7 @@ void ReactiveLayer::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 string name = objectList->get(d).asString().c_str();
                 Object* o = iCub->opc->addOrRetrieveObject(name);
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }
@@ -402,7 +402,7 @@ void ReactiveLayer::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 string name = rtobjectList->get(d).asString().c_str();
                 RTObject* o = iCub->opc->addOrRetrieveRTObject(name);
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }

--- a/main/src/modules/reservoir/lrh/src/lrh.cpp
+++ b/main/src/modules/reservoir/lrh/src/lrh.cpp
@@ -200,7 +200,7 @@ bool LRH::populateOPC(){
 
     //vGoal is : -0.350000   0.200000    0.001600
     obj1->m_ego_position = x;
-    obj1->m_present = 1;
+    obj1->m_present = 1.0;
     obj1->m_dimensions = dimensionObject;
     obj1->m_color = color;
 
@@ -213,7 +213,7 @@ bool LRH::populateOPC(){
     x[2] = 0.0016; //z position
     //vGoal is : -0.350000   0.200000    0.001600
     obj2->m_ego_position = x;
-    obj2->m_present = 1;
+    obj2->m_present = 1.0;
     obj2->m_dimensions = dimensionObject;
     obj2->m_color = color;
 
@@ -226,7 +226,7 @@ bool LRH::populateOPC(){
     x[2] = 0.0016;
     //vGoal is : -0.350000   0.200000    0.001600
     obj3->m_ego_position = x;
-    obj3->m_present = 1;
+    obj3->m_present = 1.0;
     obj3->m_dimensions = dimensionObject;
     obj3->m_color = color;
 
@@ -239,14 +239,14 @@ bool LRH::populateOPC(){
     x[2] = 0.0026;
     //vGoal is : -0.350000   0.200000    0.001600
     obj4->m_ego_position = x;
-    obj4->m_present = 1;
+    obj4->m_present = 1.0;
     obj4->m_dimensions = dimensionObject;
     obj4->m_color = color;
 
     Agent* coco = iCub->opc->addOrRetrieveEntity<Agent>("Michel");
     coco->m_ego_position[0] = -1.2;
     coco->m_ego_position[2] = 0.60;
-    coco->m_present = 1;
+    coco->m_present = 1.0;
     iCub->opc->commit();
 
     return true;
@@ -422,7 +422,7 @@ bool LRH::AREactions(vector<string> seq)
 
     bool success = true;
 
-    if (rtObject->m_present)
+    if (rtObject->m_present==1.0)
     {
 
         // GRASP BEGIN
@@ -541,7 +541,8 @@ bool LRH::spatialRelation(string sObjectFocus)
         {
             Object rto;
             rto.fromBottle((*itE)->asBottle());
-            if (rto.m_present)PresentRtoBefore.push_back(rto);
+            if (rto.m_present==1.0)
+                PresentRtoBefore.push_back(rto);
         }
     }
 

--- a/main/src/modules/reservoir/reservoirHandler/src/reservoirHandler.cpp
+++ b/main/src/modules/reservoir/reservoirHandler/src/reservoirHandler.cpp
@@ -210,7 +210,7 @@ bool reservoirHandler::populateOPC(){
 
     //vGoal is : -0.350000   0.200000    0.001600
     obj1->m_ego_position = x;
-    obj1->m_present = 1;
+    obj1->m_present = 1.0;
     obj1->m_dimensions = dimensionObject;
     obj1->m_color = color;
 
@@ -223,7 +223,7 @@ bool reservoirHandler::populateOPC(){
     x[2]=0.0016; //z position
     //vGoal is : -0.350000   0.200000    0.001600
     obj2->m_ego_position = x;
-    obj2->m_present = 1;
+    obj2->m_present = 1.0;
     obj2->m_dimensions = dimensionObject;
     obj2->m_color = color;
 
@@ -236,14 +236,14 @@ bool reservoirHandler::populateOPC(){
     x[2]=0.0016;
     //vGoal is : -0.350000   0.200000    0.001600
     obj3->m_ego_position = x;
-    obj3->m_present = 1;
+    obj3->m_present = 1.0;
     obj3->m_dimensions = dimensionObject;
     obj3->m_color = color;
 
     Agent* coco = iCub->opc->addOrRetrieveEntity<Agent>("Michel");
     coco->m_ego_position[0] = -1.2;
     coco->m_ego_position[2] = 0.60;
-    coco->m_present = 1;
+    coco->m_present = 1.0;
     iCub->opc->commit();
     return false;
 }
@@ -1214,7 +1214,7 @@ bool reservoirHandler::AREactions(vector<string> seq)
 
     bool success = true;
 
-    if (rtObject->m_present)
+    if (rtObject->m_present==1.0)
     {
 
         // GRASP BEGIN
@@ -1956,7 +1956,8 @@ bool reservoirHandler::spatialRelation()
         {
             RTObject rto;
             rto.fromBottle((*itE)->asBottle());
-            if (rto.m_present)PresentRtoBefore.push_back(rto) ;
+            if (rto.m_present==1.0)
+                PresentRtoBefore.push_back(rto) ;
         }
     }
 

--- a/main/src/modules/scenarioSpecific/gameCluedo/src/gameCluedo.cpp
+++ b/main/src/modules/scenarioSpecific/gameCluedo/src/gameCluedo.cpp
@@ -397,7 +397,7 @@ void GameCluedo::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 std::string name = agentList->get(d).asString().c_str();
                 wysiwyd::wrdac::Agent* agent = iCub->opc->addOrRetrieveEntity<Agent>(name);
-                agent->m_present = false;
+                agent->m_present = 0.0;
                 iCub->opc->commit(agent);
             }
         }
@@ -409,7 +409,7 @@ void GameCluedo::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 std::string name = objectList->get(d).asString().c_str();
                 wysiwyd::wrdac::Object* o = iCub->opc->addOrRetrieveEntity<wysiwyd::wrdac::Object>(name);
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }
@@ -421,7 +421,7 @@ void GameCluedo::configureOPC(yarp::os::ResourceFinder &rf)
             {
                 std::string name = rtobjectList->get(d).asString().c_str();
                 wysiwyd::wrdac::RTObject* o = iCub->opc->addOrRetrieveEntity<wysiwyd::wrdac::RTObject>(name);
-                o->m_present = false;
+                o->m_present = 0.0;
                 iCub->opc->commit(o);
             }
         }

--- a/main/src/modules/systemHaptic/awareTouch/src/main.cpp
+++ b/main/src/modules/systemHaptic/awareTouch/src/main.cpp
@@ -104,7 +104,7 @@ bool AwareTouch::configure(ResourceFinder &rf)
 
     world->addOrRetrieveEntity<Agent>("icub");
     touchLocation = world->addOrRetrieveEntity<Object>("touchLocation");
-    touchLocation->m_present = false;
+    touchLocation->m_present = 0.0;
     world->commit(touchLocation);
     world->addOrRetrieveEntity<Action>("is");
     world->addOrRetrieveEntity<Adjective>("none");
@@ -183,7 +183,7 @@ void AwareTouch::sendOPC(const string &partTouch, int &typeTouch, const Vector& 
    cout<<"Touch Pos:"<<posTouch.toString().c_str()<<endl;
    (touchLocation ->m_ego_position) = posTouch;
    (touchLocation ->m_dimensions) = dimensions;
-   touchLocation->m_present = true;
+   touchLocation->m_present = 1.0;
    world->commit(touchLocation);   // add position of touching
    world->addRelation(Relation("icub","is",gestureSet[typeTouch], "touchLocation"), recordingPeriod);  // add the relation with gesture
 

--- a/main/src/modules/systemVisual/iol2opc/src/module.cpp
+++ b/main/src/modules/systemVisual/iol2opc/src/module.cpp
@@ -709,7 +709,7 @@ void IOL2OPCBridge::updateOPC()
             Object *obj=opc->addOrRetrieveEntity<Object>(object);
 
             // garbage collection
-            if (it->second.isDead())
+            if (it->second.isDead() && (obj->m_present!=0.0))
             {
                 obj->m_present=0.5;
                 continue;

--- a/main/src/modules/systemVisual/iol2opc/src/module.cpp
+++ b/main/src/modules/systemVisual/iol2opc/src/module.cpp
@@ -711,7 +711,7 @@ void IOL2OPCBridge::updateOPC()
             // garbage collection
             if (it->second.isDead())
             {
-                obj->m_present=false;
+                obj->m_present=0.5;
                 continue;
             }
 
@@ -729,7 +729,7 @@ void IOL2OPCBridge::updateOPC()
                     it->second.opc_id=obj->opc_id();
                     obj->m_ego_position=x_filtered;
                     obj->m_dimensions=dim_filtered;
-                    obj->m_present=true;
+                    obj->m_present=1.0;
 
                     // threshold bbox
                     if (thresBBox(bbox,imgLatch))

--- a/main/src/modules/tools/actionRecogDataDumper/main.cpp
+++ b/main/src/modules/tools/actionRecogDataDumper/main.cpp
@@ -102,7 +102,7 @@ public:
                 bAgent.addDouble(agent->m_ego_position[0]);
                 bAgent.addDouble(agent->m_ego_position[1]);
                 bAgent.addDouble(agent->m_ego_position[2]);
-                bAgent.addInt(agent->m_present?1:0);
+                bAgent.addInt(agent->m_present==1.0?1:0);
             }
         }
 
@@ -121,7 +121,7 @@ public:
                     bObject.addDouble(object->m_ego_position[0]);
                     bObject.addDouble(object->m_ego_position[1]);
                     bObject.addDouble(object->m_ego_position[2]);
-                    bObject.addInt(object->m_present?1:0);
+                    bObject.addInt(object->m_present==1.0?1:0);
                 }
             }
         }

--- a/main/src/modules/tools/guiUpdater/src/guiUpdater.cpp
+++ b/main/src/modules/tools/guiUpdater/src/guiUpdater.cpp
@@ -184,7 +184,7 @@ bool GuiUpdater::updateModule()
                 ostringstream guiTag;
                 guiTag<< o->name() <<"("<<o->opc_id()<<")";
 
-                if (!o->m_present) {
+                if (o->m_present==0.0) {
                     deleteObject(guiTag.str(), o);
                 }
                 else

--- a/main/src/modules/tools/humanRobotDumper/src/SWSynchronizedYarpPorts.cpp
+++ b/main/src/modules/tools/humanRobotDumper/src/SWSynchronizedYarpPorts.cpp
@@ -326,7 +326,7 @@ bool humanRobotDump::updateSWS()
                 bObject.addDouble(ob->m_ego_position[0]);
                 bObject.addDouble(ob->m_ego_position[1]);
                 bObject.addDouble(ob->m_ego_position[2]);
-                bObject.addInt(ob->m_present);
+                bObject.addInt(ob->m_present==1.0?1:0);
                 l_syncDataBottle.addList() = bObject;
             }
         }

--- a/main/src/modules/tools/humanRobotDumper/src/humanRobotDump.cpp
+++ b/main/src/modules/tools/humanRobotDumper/src/humanRobotDump.cpp
@@ -250,7 +250,7 @@ void humanRobotDump::DumpHumanObject()
                 bObject.addDouble(ob->m_ego_position[0]);
                 bObject.addDouble(ob->m_ego_position[1]);
                 bObject.addDouble(ob->m_ego_position[2]);
-                bObject.addInt(ob->m_present);
+                bObject.addInt(ob->m_present==1.0?1:0);
                 bDump.addList() = bObject;
             }
         }

--- a/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
+++ b/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
@@ -156,7 +156,7 @@ bool opcPopulater::populateEntityRandom(Bottle bInput){
         agent->m_ego_position[0] = (-1.5) * (Random::uniform()) - 0.5;
         agent->m_ego_position[1] = (2) * (Random::uniform()) - 1;
         agent->m_ego_position[2] = 0.60;
-        agent->m_present = 1;
+        agent->m_present = 1.0;
         agent->m_color[0] = Random::uniform(0, 80);
         agent->m_color[1] = Random::uniform(180, 250);
         agent->m_color[2] = Random::uniform(80, 180);
@@ -171,7 +171,7 @@ bool opcPopulater::populateEntityRandom(Bottle bInput){
         obj->m_ego_position[0] = (-1.5) * (Random::uniform()) - 0.2;
         obj->m_ego_position[1] = (2) * (Random::uniform()) - 1;
         obj->m_ego_position[2] = 0.20;
-        obj->m_present = 1;
+        obj->m_present = 1.0;
         obj->m_color[0] = Random::uniform(100, 180);
         obj->m_color[1] = Random::uniform(0, 80);
         obj->m_color[2] = Random::uniform(180, 250);
@@ -185,7 +185,7 @@ bool opcPopulater::populateEntityRandom(Bottle bInput){
         RTObject* obj = iCub->opc->addOrRetrieveEntity<RTObject>(sName);
         obj->m_ego_position[0] = (-1.5) * (Random::uniform()) - 0.2;
         obj->m_ego_position[1] = (2) * (Random::uniform()) - 1;
-        obj->m_present = 1;
+        obj->m_present = 1.0;
         obj->m_color[0] = Random::uniform(180, 250);
         obj->m_color[1] = Random::uniform(100, 180);
         obj->m_color[2] = Random::uniform(0, 80);
@@ -217,7 +217,7 @@ bool opcPopulater::addUnknownEntity(Bottle bInput){
         agent->m_ego_position[0] = (-1.5) * (Random::uniform()) - 0.5;
         agent->m_ego_position[1] = (2) * (Random::uniform()) - 1;
         agent->m_ego_position[2] = 0.60;
-        agent->m_present = 1;
+        agent->m_present = 1.0;
         agent->m_color[0] = Random::uniform(0, 80);
         agent->m_color[1] = Random::uniform(180, 250);
         agent->m_color[2] = Random::uniform(80, 180);
@@ -232,7 +232,7 @@ bool opcPopulater::addUnknownEntity(Bottle bInput){
         obj->m_ego_position[0] = (-1.5) * (Random::uniform()) - 0.2;
         obj->m_ego_position[1] = (2) * (Random::uniform()) - 1;
         obj->m_ego_position[2] = 0.20;
-        obj->m_present = 1;
+        obj->m_present = 1.0;
         obj->m_color[0] = Random::uniform(100, 180);
         obj->m_color[1] = Random::uniform(0, 80);
         obj->m_color[2] = Random::uniform(180, 250);
@@ -246,7 +246,7 @@ bool opcPopulater::addUnknownEntity(Bottle bInput){
         RTObject* obj = iCub->opc->addEntity<RTObject>(sName);
         obj->m_ego_position[0] = (-1.5) * (Random::uniform()) - 0.2;
         obj->m_ego_position[1] = (2) * (Random::uniform()) - 1;
-        obj->m_present = 1;
+        obj->m_present = 1.0;
         obj->m_color[0] = Random::uniform(180, 250);
         obj->m_color[1] = Random::uniform(100, 180);
         obj->m_color[2] = Random::uniform(0, 80);
@@ -451,7 +451,7 @@ bool opcPopulater::populateABMiCubStory(Bottle bInput)
     Interlocutor->m_ego_position[0] = XInterlocutor;
     Interlocutor->m_ego_position[1] = YInterlocutor;
     Interlocutor->m_ego_position[2] = ZInterlocutor;
-    Interlocutor->m_present = 1;
+    Interlocutor->m_present = 1.0;
     Interlocutor->m_color[0] = Random::uniform(0, 80);
     Interlocutor->m_color[1] = Random::uniform(180, 250);
     Interlocutor->m_color[2] = Random::uniform(80, 180);
@@ -460,7 +460,7 @@ bool opcPopulater::populateABMiCubStory(Bottle bInput)
     ObjStory->m_ego_position[0] = XInterlocutor + distanceNat_Gir*(Random::uniform() - 0.5);
     ObjStory->m_ego_position[1] = YInterlocutor + distanceNat_Gir*(Random::uniform() - 0.5);
     ObjStory->m_ego_position[2] = 0;
-    ObjStory->m_present = 1;
+    ObjStory->m_present = 1.0;
     ObjStory->m_color[0] = Random::uniform(0, 250);
     ObjStory->m_color[1] = Random::uniform(0, 250);
     ObjStory->m_color[2] = Random::uniform(0, 250);
@@ -469,7 +469,7 @@ bool opcPopulater::populateABMiCubStory(Bottle bInput)
     icub->m_ego_position[0] = 0.0;
     icub->m_ego_position[1] = 0.0;
     icub->m_ego_position[2] = 0.0;
-    icub->m_present = 1;
+    icub->m_present = 1.0;
     icub->m_color[0] = Random::uniform(0, 80);
     icub->m_color[1] = Random::uniform(180, 250);
     icub->m_color[2] = Random::uniform(80, 180);
@@ -671,7 +671,7 @@ bool opcPopulater::populateSpecific(){
     obj1->m_ego_position[0] = X_obj + errorMargin * (Random::uniform() - 0.5);
     obj1->m_ego_position[1] = -1.* Y_obj + errorMargin * (Random::uniform() - 0.5);
     obj1->m_ego_position[2] = Z_obj + errorMargin * (Random::uniform() - 0.5);
-    obj1->m_present = 1;
+    obj1->m_present = 1.0;
     obj1->m_color[0] = Random::uniform(0, 80);
     obj1->m_color[1] = Random::uniform(80, 180);
     obj1->m_color[2] = Random::uniform(180, 250);
@@ -681,7 +681,7 @@ bool opcPopulater::populateSpecific(){
     obj2->m_ego_position[0] = X_ag + errorMargin * (Random::uniform() - 0.5);
     obj2->m_ego_position[1] = -1.* Y_ag + errorMargin * (Random::uniform() - 0.5);
     obj2->m_ego_position[2] = Z_ag + errorMargin * (Random::uniform() - 0.5);
-    obj2->m_present = 1;
+    obj2->m_present = 1.0;
     obj2->m_color[0] = Random::uniform(0, 180);
     obj2->m_color[1] = Random::uniform(0, 80);
     obj2->m_color[2] = Random::uniform(180, 250);
@@ -691,7 +691,7 @@ bool opcPopulater::populateSpecific(){
     obj3->m_ego_position[0] = X_ag + errorMargin * (Random::uniform() - 0.5);
     obj3->m_ego_position[1] = Y_ag + errorMargin * (Random::uniform() - 0.5);
     obj3->m_ego_position[2] = Z_ag + errorMargin * (Random::uniform() - 0.5);
-    obj3->m_present = 1;
+    obj3->m_present = 1.0;
     obj3->m_color[0] = Random::uniform(100, 180);
     obj3->m_color[1] = Random::uniform(80, 180);
     obj3->m_color[2] = Random::uniform(0, 80);
@@ -702,7 +702,7 @@ bool opcPopulater::populateSpecific(){
     obj4->m_ego_position[0] = X_obj + errorMargin * (Random::uniform() - 0.5);
     obj4->m_ego_position[1] = Y_obj + errorMargin * (Random::uniform() - 0.5);
     obj4->m_ego_position[2] = Z_obj + errorMargin * (Random::uniform() - 0.5);
-    obj4->m_present = 1;
+    obj4->m_present = 1.0;
     obj4->m_color[0] = Random::uniform(100, 180);
     obj4->m_color[1] = Random::uniform(0, 80);
     obj4->m_color[2] = Random::uniform(180, 250);
@@ -720,7 +720,7 @@ bool opcPopulater::populateSpecific3(){
     obj1->m_ego_position[0] = -0.4;
     obj1->m_ego_position[1] = 0.25;
     obj1->m_ego_position[2] = 0;
-    obj1->m_present = 1;
+    obj1->m_present = 1.0;
     obj1->m_color[0] = Random::uniform(0, 80);
     obj1->m_color[1] = Random::uniform(80, 180);
     obj1->m_color[2] = Random::uniform(180, 250);
@@ -730,7 +730,7 @@ bool opcPopulater::populateSpecific3(){
     obj2->m_ego_position[0] = -0.4;
     obj2->m_ego_position[1] = -0.25;
     obj2->m_ego_position[2] = 0;
-    obj2->m_present = 1;
+    obj2->m_present = 1.0;
     obj2->m_color[0] = Random::uniform(100, 180);
     obj2->m_color[1] = Random::uniform(0, 80);
     obj2->m_color[2] = Random::uniform(180, 250);
@@ -837,7 +837,7 @@ bool opcPopulater::storyFromPOV(Bottle bInput)
     Nathan->m_ego_position[0] = XNathan;
     Nathan->m_ego_position[1] = YNathan;
     Nathan->m_ego_position[2] = ZNathan;
-    Nathan->m_present = 1;
+    Nathan->m_present = 1.0;
     Nathan->m_color[0] = Random::uniform(0, 80);
     Nathan->m_color[1] = Random::uniform(180, 250);
     Nathan->m_color[2] = Random::uniform(80, 180);
@@ -846,7 +846,7 @@ bool opcPopulater::storyFromPOV(Bottle bInput)
     Giraffe->m_ego_position[0] = XNathan + distanceNat_Gir*(Random::uniform() - 0.5);
     Giraffe->m_ego_position[1] = YNathan + distanceNat_Gir*(Random::uniform() - 0.5);
     Giraffe->m_ego_position[2] = 0;
-    Giraffe->m_present = 1;
+    Giraffe->m_present = 1.0;
     Giraffe->m_color[0] = Random::uniform(0, 250);
     Giraffe->m_color[1] = Random::uniform(0, 250);
     Giraffe->m_color[2] = Random::uniform(0, 250);
@@ -855,7 +855,7 @@ bool opcPopulater::storyFromPOV(Bottle bInput)
     icub->m_ego_position[0] = 0.0;
     icub->m_ego_position[1] = 0.0;
     icub->m_ego_position[2] = 0.0;
-    icub->m_present = 1;
+    icub->m_present = 1.0;
     icub->m_color[0] = Random::uniform(0, 80);
     icub->m_color[1] = Random::uniform(180, 250);
     icub->m_color[2] = Random::uniform(80, 180);

--- a/main/src/modules/tools/qRM/include/automaticCalibrationThread.h
+++ b/main/src/modules/tools/qRM/include/automaticCalibrationThread.h
@@ -57,7 +57,7 @@ public:
     {
         opc->update(cursor);
 
-        if (cursor->m_present)
+        if (cursor->m_present==1.0)
         {
             cout<<"Trying to acquire a calibration point..."<<endl;
             Bottle* bPos = cartesianPort.read(false);

--- a/main/src/modules/tools/qRM/src/qRM.cpp
+++ b/main/src/modules/tools/qRM/src/qRM.cpp
@@ -338,7 +338,7 @@ void  qRM::mainLoop()
         for (list<Entity*>::iterator it = entities.begin(); it != entities.end(); it++)
         {
             //!!! ONLY RT_OBJECT and AGENTS ARE TRACKED !!!
-            if (((*it)->isType(EFAA_OPC_ENTITY_RTOBJECT) || (*it)->isType(EFAA_OPC_ENTITY_AGENT)) && (dynamic_cast<Object*>(*it))->m_present)
+            if (((*it)->isType(EFAA_OPC_ENTITY_RTOBJECT) || (*it)->isType(EFAA_OPC_ENTITY_AGENT)) && (dynamic_cast<Object*>(*it))->m_present==1.0)
             {
                 presentObjects.push_back(dynamic_cast<Object*>(*it));
             }
@@ -392,7 +392,7 @@ void  qRM::mainLoop()
         for (list<Entity*>::iterator it = entities.begin(); it != entities.end(); it++)
         {
             //!!! ONLY RT_OBJECT and AGENTS ARE TRACKED !!!
-            if (((*it)->isType(EFAA_OPC_ENTITY_RTOBJECT) || (*it)->isType(EFAA_OPC_ENTITY_AGENT)) && (dynamic_cast<Object*>(*it))->m_present)
+            if (((*it)->isType(EFAA_OPC_ENTITY_RTOBJECT) || (*it)->isType(EFAA_OPC_ENTITY_AGENT)) && (dynamic_cast<Object*>(*it))->m_present==1.0)
             {
                 presentObjects.push_back(dynamic_cast<Object*>(*it));
             }
@@ -619,7 +619,7 @@ bool qRM::populateOpc(){
     Agent* agent = iCub->opc->addOrRetrieveEntity<Agent>("Carol");
     agent->m_ego_position[0] = -1.4;
     agent->m_ego_position[2] = 0.60;
-    agent->m_present = 1;
+    agent->m_present = 1.0;
     agent->m_color[0] = 200;
     agent->m_color[1] = 50;
     agent->m_color[2] = 50;
@@ -1303,7 +1303,7 @@ Bottle qRM::executeAction(Bottle bInput)
                 else if (EntToGrasp->isType("object"))
                 {
                     Object *toGrasp = dynamic_cast<Object*>(iCub->opc->getEntity(sObject));
-                    if (toGrasp->m_present)
+                    if (toGrasp->m_present==1.0)
                     {
                         yarp::sig::Vector coordToGrasp = toGrasp->m_ego_position;
                         iCub->getABMClient()->sendActivity("action",
@@ -1331,7 +1331,7 @@ Bottle qRM::executeAction(Bottle bInput)
                 else if (EntToGrasp->isType("RTObject"))
                 {
                     RTObject *toGrasp = dynamic_cast<RTObject*>(iCub->opc->getEntity(sObject));
-                    if (toGrasp->m_present)
+                    if (toGrasp->m_present==1.0)
                     {
                         yarp::sig::Vector coordToGrasp = toGrasp->m_ego_position;
                         iCub->getABMClient()->sendActivity("action",
@@ -1497,7 +1497,7 @@ void qRM::populateABMGive(int iRepetition)
         ag1->m_ego_position[0] = robert_X;
         ag1->m_ego_position[1] = robert_Y;
         ag1->m_ego_position[2] = 0.30;
-        ag1->m_present = 1;
+        ag1->m_present = 1.0;
         ag1->m_color[0] = Random::uniform(0, 180);
         ag1->m_color[1] = Random::uniform(0, 80);
         ag1->m_color[2] = Random::uniform(180, 250);
@@ -1509,7 +1509,7 @@ void qRM::populateABMGive(int iRepetition)
         ag2->m_ego_position[0] = larry_X;
         ag2->m_ego_position[1] = larry_Y;
         ag2->m_ego_position[2] = 0.30;
-        ag2->m_present = 1;
+        ag2->m_present = 1.0;
         ag2->m_color[0] = Random::uniform(100, 180);
         ag2->m_color[1] = Random::uniform(80, 180);
         ag2->m_color[2] = Random::uniform(0, 80);
@@ -1519,7 +1519,7 @@ void qRM::populateABMGive(int iRepetition)
         obj->m_ego_position[0] = larry_X + 0.1 * Random::uniform();
         obj->m_ego_position[1] = larry_Y + 0.1 * Random::uniform();
         obj->m_ego_position[2] = 0.0;
-        obj->m_present = 1;
+        obj->m_present = 1.0;
         obj->m_color[0] = Random::uniform(0, 80);
         obj->m_color[1] = Random::uniform(80, 180);
         obj->m_color[2] = Random::uniform(180, 250);
@@ -1612,7 +1612,7 @@ void qRM::populateABMGive(int iRepetition)
         ag1->m_ego_position[0] = robert_X;
         ag1->m_ego_position[1] = robert_Y;
         ag1->m_ego_position[2] = 0.30;
-        ag1->m_present = 1;
+        ag1->m_present = 1.0;
         ag1->m_color[0] = Random::uniform(0, 180);
         ag1->m_color[1] = Random::uniform(0, 80);
         ag1->m_color[2] = Random::uniform(180, 250);
@@ -1624,7 +1624,7 @@ void qRM::populateABMGive(int iRepetition)
         ag2->m_ego_position[0] = larry_X;
         ag2->m_ego_position[1] = larry_Y;
         ag2->m_ego_position[2] = 0.30;
-        ag2->m_present = 1;
+        ag2->m_present = 1.0;
         ag2->m_color[0] = Random::uniform(100, 180);
         ag2->m_color[1] = Random::uniform(80, 180);
         ag2->m_color[2] = Random::uniform(0, 80);
@@ -1634,7 +1634,7 @@ void qRM::populateABMGive(int iRepetition)
         obj->m_ego_position[0] = larry_X + 0.1 * Random::uniform();
         obj->m_ego_position[1] = larry_Y + 0.1 * Random::uniform();
         obj->m_ego_position[2] = 0.0;
-        obj->m_present = 1;
+        obj->m_present = 1.0;
         obj->m_color[0] = Random::uniform(0, 80);
         obj->m_color[1] = Random::uniform(80, 180);
         obj->m_color[2] = Random::uniform(180, 250);
@@ -1748,7 +1748,7 @@ void qRM::populateABMTake(int iRepetition)
         ag1->m_ego_position[0] = XAG;
         ag1->m_ego_position[1] = YAG;
         ag1->m_ego_position[2] = 0.30;
-        ag1->m_present = 1;
+        ag1->m_present = 1.0;
         ag1->m_color[0] = Random::uniform(0, 180);
         ag1->m_color[1] = Random::uniform(0, 80);
         ag1->m_color[2] = Random::uniform(180, 250);
@@ -1766,7 +1766,7 @@ void qRM::populateABMTake(int iRepetition)
         obj->m_ego_position[0] = xObj;
         obj->m_ego_position[1] = yObj;
         obj->m_ego_position[2] = 0.0;
-        obj->m_present = 1;
+        obj->m_present = 1.0;
         obj->m_color[0] = Random::uniform(0, 80);
         obj->m_color[1] = Random::uniform(80, 180);
         obj->m_color[2] = Random::uniform(180, 250);

--- a/main/src/tests/test-are-attention/main.cpp
+++ b/main/src/tests/test-are-attention/main.cpp
@@ -53,7 +53,7 @@ int main()
     icub.lookStop();
     
     Object *object=world.addOrRetrieveEntity<Object>("BEER");    
-    object->m_present=true;
+    object->m_present=1.0;
     object->m_ego_position[0]=-0.35;
     object->m_ego_position[1]=-0.2;
     object->m_ego_position[2]=-0.1;

--- a/main/src/tests/test-cartesian-sim/main.cpp
+++ b/main/src/tests/test-cartesian-sim/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     obj1->m_ego_position[0] = X_obj;
     obj1->m_ego_position[1] = -1.* Y_obj;
     obj1->m_ego_position[2] = Z_obj;
-    obj1->m_present = 1;
+    obj1->m_present = 1.0;
     obj1->m_color[0] = Random::uniform(0, 80);
     obj1->m_color[1] = Random::uniform(80, 180);
     obj1->m_color[2] = Random::uniform(180, 250);
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     obj2->m_ego_position[0] = X_ag;
     obj2->m_ego_position[1] = -1.* Y_ag;
     obj2->m_ego_position[2] = Z_ag;
-    obj2->m_present = 1;
+    obj2->m_present = 1.0;
     obj2->m_color[0] = Random::uniform(0, 180);
     obj2->m_color[1] = Random::uniform(0, 80);
     obj2->m_color[2] = Random::uniform(180, 250);
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     obj3->m_ego_position[0] = X_ag;
     obj3->m_ego_position[1] = Y_ag;
     obj3->m_ego_position[2] = Z_ag;
-    obj3->m_present = 1;
+    obj3->m_present = 1.0;
     obj3->m_color[0] = Random::uniform(100, 180);
     obj3->m_color[1] = Random::uniform(80, 180);
     obj3->m_color[2] = Random::uniform(0, 80);
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     obj4->m_ego_position[0] = X_obj;
     obj4->m_ego_position[1] = Y_obj;
     obj4->m_ego_position[2] = Z_obj;
-    obj4->m_present = 1;
+    obj4->m_present = 1.0;
     obj4->m_color[0] = Random::uniform(100, 180);
     obj4->m_color[1] = Random::uniform(0, 80);
     obj4->m_color[2] = Random::uniform(180, 250);    

--- a/main/src/tests/test-verbRec/main.cpp
+++ b/main/src/tests/test-verbRec/main.cpp
@@ -99,7 +99,7 @@ public:
                 bAgent.addDouble(agent->m_ego_position[0]);
                 bAgent.addDouble(agent->m_ego_position[1]);
                 bAgent.addDouble(agent->m_ego_position[2]);
-                bAgent.addInt(agent->m_present?1:0);
+                bAgent.addInt(agent->m_present==1.0?1:0);
             }
         }
 
@@ -118,7 +118,7 @@ public:
                     bObject.addDouble(object->m_ego_position[0]);
                     bObject.addDouble(object->m_ego_position[1]);
                     bObject.addDouble(object->m_ego_position[2]);
-                    bObject.addInt(object->m_present?1:0);
+                    bObject.addInt(object->m_present==1.0?1:0);
                 }
             }
         }


### PR DESCRIPTION
Hi @robotology/wysiwyd-developers 

This PR deals with the problem we discussed about objects persistence.

Now, the field **`wysiwyd::wrdac::Object::m_present`** has turned into a **`double`** with the following three meanings:

- **`m_present==1.0`**: the object is currently detected by the vision system.
- **`m_present==0.5`**: vision has just stopped detecting the object and somehow regards it as an object potentially yet in the game. The value of `0.5` will trigger a specific behavior of `attentionSelector` to discover whether the object is still there, actually.
- **`m_present==0.0`**: `attentionSelector` has driven the gaze towards the object finding out that it was not there, hence the object is declared not present at all.

I went through all the present code updating the handling of `m_present` flag, trying to keep as much as possible the intended behavior unvaried.

Please review this PR very carefully.