### PR TITLE
Fixing fromBottle() signature

### DIFF
--- a/main/src/libraries/wrdac/include/wrdac/clients/opcSave.h
+++ b/main/src/libraries/wrdac/include/wrdac/clients/opcSave.h
@@ -42,7 +42,7 @@ namespace wysiwyd{namespace wrdac{
         /**
         * TODO
         */
-        void fromBottle(yarp::os::Bottle bInput);
+        void fromBottle(const yarp::os::Bottle &bInput);
 
         opcSave();
         ~opcSave();

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/action.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/action.h
@@ -91,7 +91,7 @@ namespace wysiwyd{namespace wrdac{
         */ 
                 int              size(){return subActions.size();}
         virtual yarp::os::Bottle asBottle();
-        virtual bool             fromBottle(yarp::os::Bottle b);
+        virtual bool             fromBottle(const yarp::os::Bottle &b);
         virtual std::string      toString();
                 
         /**

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/adjective.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/adjective.h
@@ -44,7 +44,7 @@ namespace wysiwyd{namespace wrdac{
         }
 
         virtual yarp::os::Bottle asBottle();
-        virtual bool             fromBottle(yarp::os::Bottle b);
+        virtual bool             fromBottle(const yarp::os::Bottle &b);
         virtual std::string      toString();
     };
 

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/agent.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/agent.h
@@ -90,7 +90,7 @@ struct Drive
         return b;
     }
 
-    bool fromBottle(yarp::os::Bottle b)
+    bool fromBottle(const yarp::os::Bottle &b)
     {
         name = b.find("name").asString().c_str();
         value = b.find("value").asDouble();
@@ -147,7 +147,7 @@ struct Body
             return b;
         }
 
-        bool fromBottle(yarp::os::Bottle b)
+        bool fromBottle(const yarp::os::Bottle &b)
         {
             for(std::map<std::string,yarp::sig::Vector>::iterator part = m_parts.begin(); part != m_parts.end(); part++)
             {
@@ -189,7 +189,7 @@ public:
         }
 
     virtual yarp::os::Bottle asBottle();
-    virtual bool             fromBottle(yarp::os::Bottle b);
+    virtual bool             fromBottle(const yarp::os::Bottle &b);
     virtual std::string      toString();
 
     /**

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/bodypart.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/bodypart.h
@@ -64,7 +64,7 @@ public:
             return this->Object::isType(_entityType);
     }
     virtual yarp::os::Bottle asBottle();
-    virtual bool             fromBottle(yarp::os::Bottle b);
+    virtual bool             fromBottle(const yarp::os::Bottle &b);
     virtual std::string      toString();
 };
 

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/conjugator.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/conjugator.h
@@ -81,7 +81,7 @@ struct VerbInfo
         return b;
     }
 
-    void fromBottle(yarp::os::Bottle b)
+    void fromBottle(const yarp::os::Bottle &b)
     {
          verbalRoot = b.find("root").asString().c_str();
          participe = b.find("participe").asString().c_str();
@@ -150,7 +150,7 @@ struct Conjugator
         return b;
     }
 
-    void fromBottle(yarp::os::Bottle b)
+    void fromBottle(const yarp::os::Bottle &b)
     {
         yarp::os::Bottle* knownsB = b.find("knownVerbs").asList();
         for(int i=0;i<knownsB->size();i++)
@@ -728,7 +728,7 @@ public:
         return b;
     }
 
-    void fromBottle(yarp::os::Bottle b)
+    void fromBottle(const yarp::os::Bottle &b)
     {
         yarp::os::Bottle *subCorpus = b.find("abstractCorpus").asList();
         for(int i=0; i<subCorpus->size(); i++)

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/entity.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/entity.h
@@ -82,7 +82,7 @@ namespace wysiwyd{namespace wrdac{
         * Fill entity fields from a bottle representation
         * @param b a pointer to the bottle containing the entity representation
         */
-        virtual bool        fromBottle(yarp::os::Bottle b);
+        virtual bool        fromBottle(const yarp::os::Bottle &b);
 
         /**
         * Return a human readable description of the entity

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/object.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/object.h
@@ -72,7 +72,7 @@ public:
         }
 
     virtual yarp::os::Bottle asBottle();
-    virtual bool             fromBottle(yarp::os::Bottle b);
+    virtual bool             fromBottle(const yarp::os::Bottle &b);
     virtual std::string      toString();
 
     /**

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/relation.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/relation.h
@@ -66,7 +66,7 @@ namespace wysiwyd{namespace wrdac{
         * Return the relation as a bottle without the argument to "none"
         */
         yarp::os::Bottle    asLightBottle(bool ignoreID = false);
-        void                fromBottle(yarp::os::Bottle b);
+        void                fromBottle(const yarp::os::Bottle &b);
         virtual std::string toString();
 
         /**

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/rtObject.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/rtObject.h
@@ -46,7 +46,7 @@ public:
                 return this->Object::isType(_entityType);
         }   
     virtual yarp::os::Bottle asBottle();
-    virtual bool             fromBottle(yarp::os::Bottle b);
+    virtual bool             fromBottle(const yarp::os::Bottle &b);
     virtual std::string      toString();
 };
 

--- a/main/src/libraries/wrdac/src/action.cpp
+++ b/main/src/libraries/wrdac/src/action.cpp
@@ -67,7 +67,7 @@ Bottle Action::asBottle()
     return b;
 }
 
-bool Action::fromBottle(Bottle b)
+bool Action::fromBottle(const Bottle &b)
 {
     if (!this->Entity::fromBottle(b))
         return false;

--- a/main/src/libraries/wrdac/src/adjective.cpp
+++ b/main/src/libraries/wrdac/src/adjective.cpp
@@ -48,7 +48,7 @@ Bottle Adjective::asBottle()
     return b;
 }
 
-bool Adjective::fromBottle(Bottle b)
+bool Adjective::fromBottle(const Bottle &b)
 {
     if (!this->Entity::fromBottle(b))
         return false;

--- a/main/src/libraries/wrdac/src/agent.cpp
+++ b/main/src/libraries/wrdac/src/agent.cpp
@@ -82,7 +82,7 @@ Bottle Agent::asBottle()
     return b;
 }
 
-bool Agent::fromBottle(Bottle b)
+bool Agent::fromBottle(const Bottle &b)
 {
     if (!this->Object::fromBottle(b))
         return false;

--- a/main/src/libraries/wrdac/src/bodypart.cpp
+++ b/main/src/libraries/wrdac/src/bodypart.cpp
@@ -84,7 +84,7 @@ string Bodypart::toString()
     return oss.str();
 }
 
-bool Bodypart::fromBottle(Bottle b)
+bool Bodypart::fromBottle(const Bottle &b)
 {
     if (!this->Object::fromBottle(b))
         return false;

--- a/main/src/libraries/wrdac/src/entity.cpp
+++ b/main/src/libraries/wrdac/src/entity.cpp
@@ -94,7 +94,7 @@ Bottle Entity::asBottleOnlyModifiedProperties()
     return new_entity;
 }
 
-bool Entity::fromBottle(Bottle b)
+bool Entity::fromBottle(const Bottle &b)
 {
     if (!b.check("name") || !b.check("entity"))
         return false;

--- a/main/src/libraries/wrdac/src/object.cpp
+++ b/main/src/libraries/wrdac/src/object.cpp
@@ -129,7 +129,7 @@ Bottle Object::asBottle()
     return b;
 }
 
-bool Object::fromBottle(Bottle b)
+bool Object::fromBottle(const Bottle &b)
 {
     if (!this->Entity::fromBottle(b))
         return false;

--- a/main/src/libraries/wrdac/src/relation.cpp
+++ b/main/src/libraries/wrdac/src/relation.cpp
@@ -177,7 +177,7 @@ Bottle Relation::asLightBottle(bool ignoreID)
 
 
 
-void Relation::fromBottle(Bottle b)
+void Relation::fromBottle(const Bottle &b)
 {        
     m_opcId = b.find("id").asInt();
     m_subject = b.find("rSubject").toString().c_str();

--- a/main/src/libraries/wrdac/src/rtObject.cpp
+++ b/main/src/libraries/wrdac/src/rtObject.cpp
@@ -69,7 +69,7 @@ string RTObject::toString()
     return oss.str();
 }
 
-bool RTObject::fromBottle(Bottle b)
+bool RTObject::fromBottle(const Bottle &b)
 {
     if (!this->Object::fromBottle(b))
         return false;

--- a/main/src/modules/abm/abmReasoning/include/spatialKnowledge.h
+++ b/main/src/modules/abm/abmReasoning/include/spatialKnowledge.h
@@ -8,7 +8,7 @@ class spatialKnowledge
 {
 public:
     std::pair<double, double>    coordRelative(double Xo, double Yo, double Xh, double Yh);      // return the relatve coordinates of an object from an other agent
-    bool                    fromBottle(yarp::os::Bottle bInput);
+    bool                    fromBottle(const yarp::os::Bottle &bInput);
 
     bool    isRelative;
     bool    isAbsolut;

--- a/main/src/modules/abm/abmReasoning/include/timeKnowledge.h
+++ b/main/src/modules/abm/abmReasoning/include/timeKnowledge.h
@@ -10,7 +10,7 @@ public:
 
     std::string                      sTemporal;
     std::pair<double, double>        coordFromString(std::string);
-    void                        fromBottle(yarp::os::Bottle bInput);
+    void                        fromBottle(const yarp::os::Bottle &bInput);
     void                        addKnowledge(yarp::os::Bottle bInput);
     std::string                      sArgument;
     int                         iSize;

--- a/main/src/modules/abm/abmReasoning/src/spatialKnowledge.cpp
+++ b/main/src/modules/abm/abmReasoning/src/spatialKnowledge.cpp
@@ -6,7 +6,7 @@ using namespace wysiwyd::wrdac;
 using namespace std;
 
 
-bool spatialKnowledge::fromBottle(Bottle bInput)
+bool spatialKnowledge::fromBottle(const Bottle &bInput)
 {
     //yInfo() << "\t"   << "input : "   << bInput.toString()    ;
 

--- a/main/src/modules/abm/abmReasoning/src/timeKnowledge.cpp
+++ b/main/src/modules/abm/abmReasoning/src/timeKnowledge.cpp
@@ -11,7 +11,7 @@ using namespace std;
 * input format :
 * <string name> <string timeArg1> <string timeArg2>
 */
-void timeKnowledge::fromBottle(Bottle bInput)
+void timeKnowledge::fromBottle(const Bottle &bInput)
 {
     if (bInput.size() != 3)
     {


### PR DESCRIPTION
This PR changes any occurrence of `fromBottle(Bottle b)` in `fromBottle(const Bottle &b)`.

@robotology/wysiwyd-developers, please be careful when selecting the signature of a function: passing parameters by value can have quite a big impact in terms of performance.

cc @Tobias-Fischer 