### PR TITLE
[behaviorManager] prioritise tagging of agent

### DIFF
--- a/main/src/modules/reactiveLayer/behaviorManager/src/tagging.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/tagging.cpp
@@ -12,6 +12,19 @@ void Tagging::run(Bottle args/*=Bottle()*/) {
     yDebug() << "send rpc to proactiveTagging";
     Bottle *sensation = sensation_port_in.read();
     int id = yarp::os::Random::uniform(0, sensation->size()-1);
+
+    // If there are unknown agents, prioritise tagging it.
+    for (int i = 0; i < sensation->size(); i++)
+    {
+        string type = sensation->get(i).asList()->get(0).asString();
+        string name = sensation->get(i).asList()->get(1).asString();
+
+        if ((type == "agent") && (name == "partner"))
+        {
+            id = i;
+        }
+    }
+
     //If there is an unknown object (to see with agents and rtobjects), add it to the rpc_command bottle, and return true
     Bottle cmd;
     Bottle rply;


### PR DESCRIPTION
@Tobias-Fischer 
The `tagging` behaviour now tags unknown agents before unknown objects. As yet untested due to technical issues here, but as the changes are small they should work fine.