### PR TITLE
[agentDetector] Calibrate with more than one object on the table

### DIFF
--- a/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.cpp
+++ b/main/src/modules/humanUnderstanding/agentDetector/AgentDetector.cpp
@@ -446,9 +446,18 @@ bool AgentDetector::updateModule()
             list<Entity*> presentObjects=opc->Entities(bCond);
             opc->isVerbose=false;
             
-            if (presentObjects.size()==1)
-            {
-                Object* o=(Object*)(presentObjects.front());
+            Object *o=nullptr;
+            if (presentObjects.size()==1) {
+                o=dynamic_cast<Object*>(presentObjects.front());
+            } else {
+                for(auto& presentObject : presentObjects) {
+                    if(presentObject->name() == "target") {
+                        o=dynamic_cast<Object*>(presentObject);
+                        break;
+                    }
+                }
+            }
+            if(o) {
                 Bottle botRPH, botRPHRep;
                 botRPH.addString("add");
                 botRPH.addString("kinect");
@@ -466,9 +475,11 @@ bool AgentDetector::updateModule()
                 cout<<"Got from RFH: "<<botRPHRep.toString().c_str()<<endl;
 
                 pointsCnt++;
-            }
-            else
+            } else {
                 yWarning("There should be 1 and only 1 object on the table");
+                yWarning("If there is more than one object, the object you want");
+                yWarning("to calibrate must be called \"target\"");
+            }
         }
         else if (AgentDetector::clicked==clicked_right)
         {


### PR DESCRIPTION
- Either calibrate on the single object on the table, or calibrate with the object called "target"
- Adapt warning message accordingly
- Use dynamic_cast instead of old style casts
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216262442%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216262925%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216262983%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216263366%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216264432%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216265157%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216268658%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216268729%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-217450705%22%2C%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-217466703%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/wysiwyd/pull/128%23issuecomment-216262442%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20fixes%20https%3A//github.com/robotology/wysiwyd/issues/118%5Cr%5Cn%5Cr%5CnBest%2C%20Tobi%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A09%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40maxime-petit%3A%20Please%20check%20whether%20this%20is%20what%20you%20imagined.%20We%20have%20to%20check%20whether%20this%20works%20on%20the%20robot%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A11%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pattacini%3A%20Checking%20for%20an%20object%20with%20a%20predefined%20name%20is%20the%20best%20I%20could%20come%20up%20with.%20Do%20you%20have%20a%20better%20idea%3F%5Cr%5CnAlso%2C%20how%20does%20the%20CodeReviewHub%20work%3F%20I%20thought%20adding%20a%20new%20comment%20adds%20a%20new%20task%20on%20the%20task%20list%2C%20but%20this%20does%20not%20seem%20to%20be%20the%20case%20..%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A11%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20this%20is%20exactly%20what%20I%20had%20in%20mind%20%3Asmile%3A%20%5Cr%5CnI%27ve%20gone%20though%20the%20code%20and%20I%27m%20fine%20with%20this%20PR.%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A12%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Tobias-Fischer%20I%27ve%20seen%20%60CodeReviewHub%60%20working%20against%20inline%20comments%20%28see%20e.g.%20https%3A//github.com/tanismar/objects3DModeler/pull/1%29%2C%20but%20maybe%20doesn%27t%20do%20the%20same%20job%20for%20general%20comments.%20Could%20it%20be%20because%20you%20edited%20the%20comment%3F%20Don%27t%20know...%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A16%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%20perfect%3A%29%20%5Cr%5Cn%5Cr%5CnWe%20will%20just%20have%20to%20try%20in%20live%20tomorrow%5Cr%5Cn%5Cr%5CnSo%20we%20have%20now%202%20%5C%22special%5C%22%20objects%3A%20partner%20and%20target%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A19%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4256170%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/maxime-petit%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A31%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-05-02T15%3A31%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20tested%2C%20it%20is%20working%20fine%21%5Cr%5Cn%5Cr%5CnJust%20make%20sure%20to%20use%20change_name%20from%20/iol2rpc/rpc%20and%20DO%20NOT%20use%20a%20direct%20changing%20name%20from%20/OPC/rpc%2C%20otherwise%20the%20tracking%20of%20the%20target%20object%20is%20not%20done%20%3A%29%5Cr%5Cn%5Cr%5Cn./Max%22%2C%20%22created_at%22%3A%20%222016-05-06T14%3A11%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4256170%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/maxime-petit%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40maxime-petit%2C%5Cr%5CnYes%2C%20if%20you%20don%27t%20use%20%60change_name%60%2C%20then%20%60iol2opc%60%20is%20not%20aware%20that%20the%20name%20has%20changed.%20This%20is%20properly%20done%20within%20the%20%60iCubClient%60%20subsystems%20%3A%29.%5Cr%5Cn%5Cr%5CnThanks%20for%20checking%21%21%21%5Cr%5Cn%5Cr%5CnBest%2C%20Tobi%22%2C%20%22created_at%22%3A%20%222016-05-06T15%3A01%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/pattacini%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/pattacini'><img src='https://avatars.githubusercontent.com/u/3738070?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/wysiwyd/pull/128#issuecomment-216262442'>General Comment</a></b>
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> This fixes https://github.com/robotology/wysiwyd/issues/118
Best, Tobi
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> @maxime-petit: Please check whether this is what you imagined. We have to check whether this works on the robot
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> @pattacini: Checking for an object with a predefined name is the best I could come up with. Do you have a better idea?
Also, how does the CodeReviewHub work? I thought adding a new comment adds a new task on the task list, but this does not seem to be the case ..
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @Tobias-Fischer this is exactly what I had in mind :smile:
I've gone though the code and I'm fine with this PR.
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> @Tobias-Fischer I've seen `CodeReviewHub` working against inline comments (see e.g. https://github.com/tanismar/objects3DModeler/pull/1), but maybe doesn't do the same job for general comments. Could it be because you edited the comment? Don't know...
- <a href='https://github.com/maxime-petit'><img border=0 src='https://avatars.githubusercontent.com/u/4256170?v=3' height=16 width=16'></a> Yep perfect:)
We will just have to try in live tomorrow
So we have now 2 "special" objects: partner and target :)
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/maxime-petit'><img border=0 src='https://avatars.githubusercontent.com/u/4256170?v=3' height=16 width=16'></a> Just tested, it is working fine!
Just make sure to use change_name from /iol2rpc/rpc and DO NOT use a direct changing name from /OPC/rpc, otherwise the tracking of the target object is not done :)
./Max
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Hi @maxime-petit,
Yes, if you don't use `change_name`, then `iol2opc` is not aware that the name has changed. This is properly done within the `iCubClient` subsystems :).
Thanks for checking!!!
Best, Tobi


<a href='https://www.codereviewhub.com/robotology/wysiwyd/pull/128?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/wysiwyd/pull/128?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/wysiwyd/pull/128?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/wysiwyd/pull/128'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>