### PR TITLE
Feature/upf/value

### DIFF
--- a/main/app/demos/scripts/PPS_with_valence_and_stress_Test.xml
+++ b/main/app/demos/scripts/PPS_with_valence_and_stress_Test.xml
@@ -1,0 +1,246 @@
+<application>
+    <name>PPS_with_valence_and_stress_Test</name>
+
+    <dependencies>
+    </dependencies>
+   
+  
+    <module>
+        <name>pf3dTracker</name>
+        <parameters>--from pf3dTracker.ini</parameters>
+        <node>localhost</node>
+        <tag>PF3DTracker</tag>
+    </module>
+    <module>
+        <name>yarpview</name>
+        <parameters>--name /PF3DT_viewer --RefreshTime 33 --x 1400 --y 0 --w 320 --h 260 --compact</parameters>
+        <node>localhost</node>
+        <tag>PF3DTracker_viewer</tag>
+    </module>
+
+    <module> 
+        <name>visuoTactileWrapper</name>
+        <parameters>--noDoubleTouch</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+     </module>
+
+    <module>
+        <name>visuoTactileRF</name>
+        <parameters>--taxelsFile taxels1D_learnedAll.ini --rate 20</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+    </module>
+    <module>
+        <name>ppsAggregEventsForiCubGui</name>
+        <parameters></parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+        <tag>aggregEvForiCubGui</tag>
+    </module>
+
+  
+    <!--module>
+        <name>yarpview</name>
+        <parameters>--name /vtRF/left --RefreshTime 33 --x 0 --y 0 --w 400 --h 400 --compact</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+    </module>
+    <module>
+        <name>yarpview</name>
+        <parameters>--name /vtRF/right --RefreshTime 33 --x 420 --y 0 --w 400 --h 400 --compact</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+    </module-->
+     
+    <module>
+        <name>objectsPropertiesCollector</name>
+        <parameters>--name OPC --no-load-db --no-save-db</parameters>
+        <node>localhost</node>
+    </module>
+    <module>
+      <name>sensationManager</name>
+      <parameters>--from pps.ini</parameters>
+	  <node>localhost</node>
+	<tag>sensationManager</tag>
+   </module>
+   <module>
+      <name>homeostasis</name>
+      <parameters>--from pps.ini</parameters>
+      <node>localhost</node>
+    <tag>homeostasis</tag>
+   </module>
+   <module>
+      <name>allostaticController</name>
+      <parameters>--from pps.ini</parameters>
+      <node>localhost</node>
+    <tag>allostaticController</tag>
+   </module>
+   <module>
+      <name>behaviorManager</name>
+      <parameters>--from pps.ini</parameters>
+      <node>localhost</node>
+    <tag>behaviorManager</tag>
+   </module>
+
+    <module>
+        <name>guiUpdater</name>
+        <parameters>--displaySkeletons 1</parameters>
+        <node>localhost</node>
+    </module>
+    <module>
+        <name>opcPopulater</name>
+        <parameters></parameters>
+        <node>localhost</node>
+    </module>
+
+
+     <module>
+        <name>iCubGui</name>
+        <parameters>--xpos 1300 --ypos 330 --width 450 --height 550</parameters>
+        <node>localhost</node>
+    </module>
+
+    <!--module>
+        <name></name>
+        <parameters></parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+        <tag></tag>
+    </module-->
+  
+     <connection>
+        <from>/icub/camcalib/left/out</from>
+        <to>/pf3dTracker/video:i</to>
+        <protocol>udp</protocol>
+    </connection>     
+    <connection>
+        <from>/pf3dTracker/video:o</from>
+        <to>/PF3DT_viewer</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/pf3dTracker/data:o</from>
+        <to>/visuoTactileWrapper/pf3dTracker:i</to>
+        <protocol>udp</protocol>
+    </connection>
+
+     <connection>
+        <from>/opcSensation/objects:o</from>
+	    <to>/visuoTactileWrapper/sensManager:i</to>
+        <protocol>udp</protocol>
+     </connection>
+
+     <connection>
+        <from>/visuoTactileWrapper/events:o</from>
+        <to>/visuoTactileRF/events:i</to>
+        <protocol>udp</protocol>
+    </connection>
+
+     <connection>
+        <from>/skinManager/skin_events:o</from>
+        <to>/visuoTactileRF/skin_events:i</to>
+        <protocol>udp</protocol>
+    </connection>
+
+
+     <connection>
+        <from>/visuoTactileWrapper/gui:o</from>
+        <to>/iCubGui/objects</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/visuoTactileRF/pps_events_aggreg:o</from>
+	    <to>/ppsAggregEventsForiCubGui/pps_events_aggreg:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/ppsAggregEventsForiCubGui/contacts:o</from>
+	    <to>/iCubGui/forces</to>
+        <protocol>udp</protocol>
+    </connection>
+        
+      
+    <!--connection>
+        <from>/icub/camcalib/left/out</from>
+        <to>/visuoTactileRF/imageL:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/camcalib/right/out</from>
+        <to>/visuoTactileRF/imageR:i</to>
+        <protocol>udp</protocol>
+    </connection-->
+   
+   
+   
+    <connection>
+    <from>/visuoTactileRF/skinGuiForearmL:o</from>
+        <to>/skinGui/left_forearm_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+    <from>/visuoTactileRF/skinGuiForearmR:o</from>
+        <to>/skinGui/right_forearm_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+    <from>/visuoTactileRF/skinGuiHandL:o</from>
+        <to>/skinGui/left_hand_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+    <from>/visuoTactileRF/skinGuiHandR:o</from>
+        <to>/skinGui/right_hand_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+ 
+      <connection>
+        <from>/guiUpdater/gui:o</from>
+        <to>/iCubGui/objects</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/guiUpdater/guiBase:o</from>
+        <to>/iCubGui/base:i</to>
+        <protocol>udp</protocol>
+    </connection>
+   
+    <connection>
+        <from>/icub/head/state:o</from>
+        <to>/iCubGui/head:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/inertial</from>
+        <to>/iCubGui/inertial:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/left_arm/state:o</from>
+        <to>/iCubGui/left_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/right_arm/state:o</from>
+        <to>/iCubGui/right_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/torso/state:o</from>
+        <to>/iCubGui/torso:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <!--connection>
+        <from>/skinManager/skin_events:o</from>
+        <to>/iCubGui/forces</to>
+        <protocol>udp</protocol>
+    </connection-->
+
+
+    <!--connection>
+        <from></from>
+	<to></to>
+        <protocol>udp</protocol>
+    </connection-->
+</application>

--- a/main/app/demos/scripts/PPS_with_valence_and_stress_Test.xml
+++ b/main/app/demos/scripts/PPS_with_valence_and_stress_Test.xml
@@ -231,6 +231,11 @@
         <to>/iCubGui/torso:i</to>
         <protocol>udp</protocol>
     </connection>
+    <connection>
+        <from>/homeostasis/stress:o</from>
+        <to>/visuoTactileRF/stress:i</to>
+        <protocol>udp</protocol>
+    </connection>
     <!--connection>
         <from>/skinManager/skin_events:o</from>
         <to>/iCubGui/forces</to>

--- a/main/app/demos/scripts/PPS_with_valence_and_stress_Test_icubSim.xml
+++ b/main/app/demos/scripts/PPS_with_valence_and_stress_Test_icubSim.xml
@@ -1,0 +1,258 @@
+<application>
+    <name>PPS_with_valence_and_stress_test_icubSim</name>
+
+    <dependencies>
+    </dependencies>
+   
+    <module> 
+        <name>iCub_SIM</name>
+        <parameters></parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+    </module>
+
+    <module> 
+        <name>iKinGazeCtrl</name>
+        <parameters>--from configSim.ini</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+    </module>
+
+    <module> 
+        <name>visuoTactileWrapper</name>
+        <parameters>--noDoubleTouch --robot icubSim</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+    </module>
+
+    <module>
+        <name>visuoTactileRF</name>
+        <parameters>--taxelsFile taxels1D_learnedAll.ini --rate 20 --robot icubSim</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+    </module>
+ 
+    <module>
+        <name>ppsAggregEventsForiCubGui</name>
+        <parameters></parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+        <tag>aggregEvForiCubGui</tag>
+    </module>
+
+  
+     <!--module>
+        <name>yarpview</name>
+        <parameters>--name /vtRF/left --RefreshTime 33 --x 0 --y 0 --w 400 --h 400 --compact</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+     </module>
+     <module>
+        <name>yarpview</name>
+        <parameters>--name /vtRF/right --RefreshTime 33 --x 420 --y 0 --w 400 --h 400 --compact</parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+     </module-->
+     
+    <module>
+        <name>objectsPropertiesCollector</name>
+        <parameters>--name OPC --no-load-db --no-save-db</parameters>
+        <node>localhost</node>
+    </module>
+    <module>
+        <name>sensationManager</name>
+        <parameters>--from pps.ini</parameters>
+        <node>localhost</node>
+        <tag>sensationManager</tag>
+    </module>
+    <module>
+        <name>homeostasis</name>
+        <parameters>--from pps.ini</parameters>
+        <node>localhost</node>
+        <tag>homeostasis</tag>
+    </module>
+    <module>
+        <name>allostaticController</name>
+        <parameters>--from pps.ini</parameters>
+        <node>localhost</node>
+        <tag>allostaticController</tag>
+    </module>
+    <module>
+        <name>behaviorManager</name>
+        <parameters>--from pps.ini</parameters>
+        <node>localhost</node>
+        <tag>behaviorManager</tag>
+    </module>
+
+    <module>
+        <name>guiUpdater</name>
+        <parameters>--displaySkeletons 1</parameters>
+        <node>localhost</node>
+    </module>
+    <module>
+        <name>opcPopulater</name>
+        <parameters></parameters>
+        <node>localhost</node>
+    </module>
+
+    <module>
+        <name>iCubGui</name>
+        <parameters>--xpos 1300 --ypos 330 --width 450 --height 550</parameters>
+        <node>localhost</node>
+    </module>
+
+    <module>
+        <name>iCubSkinGui</name>
+        <!-- Remember to use the proper configuration files (i.e. "_V2.ini" for V2 robots) -->
+        <parameters>--from left_forearm.ini --useCalibration --xpos 0 --ypos 0 --width 300 --height 300</parameters>
+        <node>localhost</node>
+        <tag>skinGuiLF</tag>
+    </module>
+    <module>
+        <name>iCubSkinGui</name>
+        <!-- Remember to use the proper configuration files (i.e. "_V2.ini" for V2 robots) -->
+        <parameters>--from left_hand_V2_1.ini --useCalibration --xpos 320 --ypos 0 --width 300 --height 300</parameters>
+        <node>localhost</node>
+        <tag>skinGuiLH</tag>
+    </module>
+    <module>
+        <name>iCubSkinGui</name>
+        <!-- Remember to use the proper configuration files (i.e. "_V2.ini" for V2 robots) -->
+        <parameters>--from right_forearm.ini --useCalibration --xpos 640 --ypos 0 --width 300 --height 300</parameters>
+        <node>localhost</node>
+        <tag>skinGuiRF</tag>
+    </module>
+    <module>
+        <name>iCubSkinGui</name>
+        <!-- Remember to use the proper configuration files (i.e. "_V2.ini" for V2 robots) --> 
+        <parameters>--from right_hand_V2_1.ini --useCalibration --xpos 960 --ypos 0 --width 300 --height 300</parameters>
+        <node>localhost</node>
+        <tag>skinGuiRH</tag>
+    </module>
+  
+    <!--module>
+        <name></name>
+        <parameters></parameters>
+        <node>localhost</node>
+        <stdio></stdio>
+        <tag></tag>
+    </module-->
+  
+    <connection>
+        <from>/opcSensation/objects:o</from>
+        <to>/visuoTactileWrapper/sensManager:i</to>
+        <protocol>udp</protocol>
+    </connection>
+
+    <connection>
+        <from>/visuoTactileWrapper/events:o</from>
+        <to>/visuoTactileRF/events:i</to>
+        <protocol>udp</protocol>
+    </connection>
+
+    <connection>
+        <from>/skinManager/skin_events:o</from>
+        <to>/visuoTactileRF/skin_events:i</to>
+        <protocol>udp</protocol>
+    </connection>
+
+
+    <connection>
+        <from>/visuoTactileWrapper/gui:o</from>
+        <to>/iCubGui/objects</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/visuoTactileRF/pps_events_aggreg:o</from>
+        <to>/ppsAggregEventsForiCubGui/pps_events_aggreg:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/ppsAggregEventsForiCubGui/contacts:o</from>
+        <to>/iCubGui/forces</to>
+        <protocol>udp</protocol>
+    </connection>
+     
+    <connection>
+        <from>/homeostasis/stress:o</from>
+        <to>/visuoTactileRF/stress:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    
+    <!--connection>
+        <from>/icub/camcalib/left/out</from>
+        <to>/visuoTactileRF/imageL:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/camcalib/right/out</from>
+        <to>/visuoTactileRF/imageR:i</to>
+        <protocol>udp</protocol>
+    </connection-->
+   
+    <connection>
+        <from>/visuoTactileRF/skinGuiForearmL:o</from>
+        <to>/skinGui/left_forearm_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/visuoTactileRF/skinGuiForearmR:o</from>
+        <to>/skinGui/right_forearm_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/visuoTactileRF/skinGuiHandL:o</from>
+        <to>/skinGui/left_hand_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/visuoTactileRF/skinGuiHandR:o</from>
+        <to>/skinGui/right_hand_virtual:i</to>
+        <protocol>udp</protocol>
+    </connection>
+ 
+    <connection>
+        <from>/guiUpdater/gui:o</from>
+        <to>/iCubGui/objects</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/guiUpdater/guiBase:o</from>
+        <to>/iCubGui/base:i</to>
+        <protocol>udp</protocol>
+    </connection>
+   
+    <connection>
+        <from>/icubSim/head/state:o</from>
+        <to>/iCubGui/head:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/inertial</from>
+        <to>/iCubGui/inertial:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/left_arm/state:o</from>
+        <to>/iCubGui/left_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/right_arm/state:o</from>
+        <to>/iCubGui/right_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icubSim/torso/state:o</from>
+        <to>/iCubGui/torso:i</to>
+        <protocol>udp</protocol>
+    </connection>
+
+
+    <!--connection>
+        <from></from>
+        <to></to>
+        <protocol>udp</protocol>
+    </connection-->
+    
+</application>

--- a/main/app/demos/scripts/ReactiveTestingMode.xml
+++ b/main/app/demos/scripts/ReactiveTestingMode.xml
@@ -1,0 +1,35 @@
+<application>
+    <name>ReactiveLayer Test Mode</name>
+
+    <module>
+      <name>sensationManager</name>
+      <parameters>--from test.ini</parameters>
+	  <node>jy</node>
+	<tag>sensationManager</tag>
+   </module>
+   <module>
+      <name>ears</name>
+      <parameters></parameters>
+      <node>jy</node>
+    <tag>ears</tag>
+   </module>
+   <module>
+      <name>homeostasis</name>
+      <parameters></parameters>
+      <node>jy</node>
+    <tag>homeostasis</tag>
+   </module>
+   <module>
+      <name>allostaticController</name>
+      <parameters>--from test.ini</parameters>
+      <node>jy</node>
+    <tag>allostaticController</tag>
+   </module>
+   <module>
+      <name>behaviorManager</name>
+      <parameters>--from test.ini</parameters>
+      <node>jy</node>
+    <tag>behaviorManager</tag>
+   </module>
+
+</application>

--- a/main/app/demos/scripts/ReactiveTestingMode.xml
+++ b/main/app/demos/scripts/ReactiveTestingMode.xml
@@ -4,31 +4,31 @@
     <module>
       <name>sensationManager</name>
       <parameters>--from test.ini</parameters>
-	  <node>jy</node>
+	  <node>localhost</node>
 	<tag>sensationManager</tag>
    </module>
    <module>
       <name>ears</name>
       <parameters></parameters>
-      <node>jy</node>
+      <node>localhost</node>
     <tag>ears</tag>
    </module>
    <module>
       <name>homeostasis</name>
       <parameters></parameters>
-      <node>jy</node>
+      <node>localhost</node>
     <tag>homeostasis</tag>
    </module>
    <module>
       <name>allostaticController</name>
       <parameters>--from test.ini</parameters>
-      <node>jy</node>
+      <node>localhost</node>
     <tag>allostaticController</tag>
    </module>
    <module>
       <name>behaviorManager</name>
       <parameters>--from test.ini</parameters>
-      <node>jy</node>
+      <node>localhost</node>
     <tag>behaviorManager</tag>
    </module>
 

--- a/main/app/demos/scripts/TestingValueSystem.xml
+++ b/main/app/demos/scripts/TestingValueSystem.xml
@@ -1,0 +1,72 @@
+<application>
+    <name>Value System</name>
+
+    <module>
+        <name>objectsPropertiesCollector</name>
+        <parameters>--name OPC --no-load-db --no-save-db</parameters>
+        <node>jy</node>
+    </module>
+    <module>
+      <name>sensationManager</name>
+      <parameters></parameters>
+	  <node>jy</node>
+	<tag>sensationManager</tag>
+   </module>
+
+    <module>
+        <name>guiUpdater</name>
+        <parameters>--displaySkeletons 1</parameters>
+        <node>jy</node>
+    </module>
+    <module>
+        <name>opcPopulater</name>
+        <parameters></parameters>
+        <node>jy</node>
+    </module>
+
+    <module>
+        <name>iCubGui</name>
+        <parameters>--xpos 2010 --ypos 520 --width 650 --height 550</parameters>
+        <node>jy</node>
+    </module>
+<connection>
+        <from>/guiUpdater/gui:o</from>
+        <to>/iCubGui/objects</to>
+        <protocol>tcp</protocol>
+    </connection>
+    <connection>
+        <from>/guiUpdater/guiBase:o</from>
+        <to>/iCubGui/base:i</to>
+        <protocol>tcp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/head/state:o</from>
+        <to>/iCubGui/head:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/inertial</from>
+        <to>/iCubGui/inertial:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/left_arm/state:o</from>
+        <to>/iCubGui/left_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/right_arm/state:o</from>
+        <to>/iCubGui/right_arm:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/icub/torso/state:o</from>
+        <to>/iCubGui/torso:i</to>
+        <protocol>udp</protocol>
+    </connection>
+    <connection>
+        <from>/skinManager/skin_events:o</from>
+        <to>/iCubGui/forces</to>
+        <protocol>udp</protocol>
+    </connection>
+</application>

--- a/main/app/reactiveLayer/allostaticController/conf/pps.ini
+++ b/main/app/reactiveLayer/allostaticController/conf/pps.ini
@@ -1,0 +1,29 @@
+
+
+[ALLOSTATIC]
+drives										(dummy, dummy2)
+
+dummy-homeostasisMin          0.25
+dummy-homeostasisMax          1.0
+dummy-decay                   0.02
+dummy-priority                1
+dummy-under-behavior          dummy
+dummy-under-behavior-port     /BehaviorManager/trigger:i
+dummy-sensation-port          /Sensation/test/out
+dummy-sensation-on            ((par dummy val 0.5))
+dummy-sensation-off           ((par dummy dec 0.02))
+dummy-before-trigger          ((par dummy val 0.5) (par dummy dec 0.0) (freeze all))
+dummy-after-trigger           ((unfreeze all) (par dummy val 0.5))
+
+
+dummy2-homeostasisMin          0.25
+dummy2-homeostasisMax          1.0
+dummy2-decay                   0.01
+dummy2-priority                1
+dummy2-under-behavior          dummy2
+dummy2-under-behavior-port     /BehaviorManager/trigger:i
+dummy2-sensation-port          /Sensation/test/out
+dummy2-sensation-on            ((par dummy2 val 0.5))
+dummy2-sensation-off           ((par dummy2 dec 0.02))
+dummy2-before-trigger          ((par dummy2 val 0.5) (par dummy2 dec 0.0) (freeze all))
+dummy2-after-trigger           ((unfreeze all) (par dummy2 val 0.5))

--- a/main/app/reactiveLayer/allostaticController/conf/test.ini
+++ b/main/app/reactiveLayer/allostaticController/conf/test.ini
@@ -5,25 +5,25 @@ drives										(dummy, dummy2)
 
 dummy-homeostasisMin          0.25
 dummy-homeostasisMax          1.0
-dummy-decay                   0.05
+dummy-decay                   0.02
 dummy-priority                1
 dummy-under-behavior          dummy
 dummy-under-behavior-port     /BehaviorManager/trigger:i
 dummy-sensation-port          /Sensation/test/out
 dummy-sensation-on            ((par dummy val 0.5))
-dummy-sensation-off           ((par dummy dec 0.05))
+dummy-sensation-off           ((par dummy dec 0.02))
 dummy-before-trigger          ((par dummy val 0.5) (par dummy dec 0.0) (freeze all))
 dummy-after-trigger           ((unfreeze all) (par dummy val 0.5))
 
 
 dummy2-homeostasisMin          0.25
 dummy2-homeostasisMax          1.0
-dummy2-decay                   0.1
+dummy2-decay                   0.01
 dummy2-priority                1
 dummy2-under-behavior          dummy2
 dummy2-under-behavior-port     /BehaviorManager/trigger:i
 dummy2-sensation-port          /Sensation/test/out
 dummy2-sensation-on            ((par dummy2 val 0.5))
-dummy2-sensation-off           ((par dummy2 dec 0.1))
+dummy2-sensation-off           ((par dummy2 dec 0.02))
 dummy2-before-trigger          ((par dummy2 val 0.5) (par dummy2 dec 0.0) (freeze all))
 dummy2-after-trigger           ((unfreeze all) (par dummy2 val 0.5))

--- a/main/app/reactiveLayer/behaviorManager/conf/default.ini
+++ b/main/app/reactiveLayer/behaviorManager/conf/default.ini
@@ -5,6 +5,7 @@ ttsOptions      "iCub"
 
 use_ears        true
 
+
 [followingOrder]
 ks1 (15126)
 ks2 (15144)

--- a/main/app/reactiveLayer/behaviorManager/conf/pps.ini
+++ b/main/app/reactiveLayer/behaviorManager/conf/pps.ini
@@ -1,0 +1,4 @@
+[BEHAVIORS]
+
+behaviors	(dummy, dummy2)
+ttsOptions      "iCub"

--- a/main/app/reactiveLayer/behaviorManager/conf/pps.ini
+++ b/main/app/reactiveLayer/behaviorManager/conf/pps.ini
@@ -2,3 +2,4 @@
 
 behaviors	(dummy, dummy2)
 ttsOptions      "iCub"
+use_ears false

--- a/main/app/reactiveLayer/behaviorManager/conf/test.ini
+++ b/main/app/reactiveLayer/behaviorManager/conf/test.ini
@@ -2,3 +2,5 @@
 
 behaviors	(dummy, dummy2)
 ttsOptions      "iCub"
+
+use_ears false

--- a/main/app/reactiveLayer/homeostasis/conf/default.ini
+++ b/main/app/reactiveLayer/homeostasis/conf/default.ini
@@ -1,8 +1,11 @@
 name                                homeostasis
 period                              0.1
+stress-k	15
+stress-th	-0.55
 
 [HOMEOSTATIC]
 drives                                      ()
+
 
 
 # Drives should rather been defined in the allostatic controller

--- a/main/app/reactiveLayer/homeostasis/conf/pps.ini
+++ b/main/app/reactiveLayer/homeostasis/conf/pps.ini
@@ -1,5 +1,7 @@
 name                                homeostasis
 period                              0.01
+stress-k	15
+stress-th	-0.55
 
 [HOMEOSTATIC]
 drives                                      ()

--- a/main/app/reactiveLayer/homeostasis/conf/pps.ini
+++ b/main/app/reactiveLayer/homeostasis/conf/pps.ini
@@ -1,0 +1,11 @@
+name                                homeostasis
+period                              0.01
+
+[HOMEOSTATIC]
+drives                                      ()
+
+
+# Drives should rather been defined in the allostatic controller
+sample-homeostasisMin          0.25
+sample-homeostasisMax          1.0
+sample-decay                   0.0

--- a/main/app/reactiveLayer/homeostasis/conf/pps.ini
+++ b/main/app/reactiveLayer/homeostasis/conf/pps.ini
@@ -3,9 +3,3 @@ period                              0.01
 
 [HOMEOSTATIC]
 drives                                      ()
-
-
-# Drives should rather been defined in the allostatic controller
-sample-homeostasisMin          0.25
-sample-homeostasisMax          1.0
-sample-decay                   0.0

--- a/main/app/reactiveLayer/homeostasis/conf/test.ini
+++ b/main/app/reactiveLayer/homeostasis/conf/test.ini
@@ -1,5 +1,7 @@
 name                                homeostasis
 period                              0.1
+stress-k	15
+stress-th	-0.55
 
 [HOMEOSTATIC]
 

--- a/main/app/reactiveLayer/sensationManager/conf/pps.ini
+++ b/main/app/reactiveLayer/sensationManager/conf/pps.ini
@@ -1,0 +1,3 @@
+
+[SENSATIONS]
+sensations	(test opcSensation)

--- a/main/src/libraries/wrdac/include/wrdac/knowledge/object.h
+++ b/main/src/libraries/wrdac/include/wrdac/knowledge/object.h
@@ -74,6 +74,11 @@ public:
     */
     ObjectArea m_objectarea;
 
+    /**
+    * A measurement of the object subjective value [0,1]
+    */  
+    double          m_value;
+
     virtual bool    isType(std::string _entityType)
     {
         if (_entityType == EFAA_OPC_ENTITY_OBJECT) {

--- a/main/src/libraries/wrdac/include/wrdac/tags.h
+++ b/main/src/libraries/wrdac/include/wrdac/tags.h
@@ -51,6 +51,8 @@
 #define EFAA_OPC_OBJECT_RTDIMY_TAG          ("rt_dim_y")
 #define EFAA_OPC_OBJECT_RTDIMZ_TAG          ("rt_dim_z")
 #define EFAA_OPC_OBJECT_SALIENCY            ("saliency")
+#define EFAA_OPC_OBJECT_VALUE               ("value")
+#define EFAA_OPC_OBJECT_CURID_TAG           ("cur_id")
 
 #define EFAA_OPC_OBJECT_ROBOTPOS_TAG        ("position_3d")
 #define EFAA_OPC_OBJECT_ROBOTPOSX_TAG       ("robot_position_x")

--- a/main/src/libraries/wrdac/src/knowledge/object.cpp
+++ b/main/src/libraries/wrdac/src/knowledge/object.cpp
@@ -164,8 +164,7 @@ bool Object::fromBottle(const Bottle &b)
         !b.check(EFAA_OPC_OBJECT_GUI_COLOR_G) ||
         !b.check(EFAA_OPC_OBJECT_GUI_COLOR_B) ||
         !b.check(EFAA_OPC_OBJECT_PRESENT_TAG) ||
-        !b.check("object_area")
-       )
+        !b.check("object_area")               ||
         !b.check(EFAA_OPC_OBJECT_VALUE))
     {
         return false;

--- a/main/src/libraries/wrdac/src/knowledge/object.cpp
+++ b/main/src/libraries/wrdac/src/knowledge/object.cpp
@@ -34,6 +34,7 @@ Object::Object():Entity()
     m_dimensions.resize(3,0.1);
     m_color.resize(3,255.0);
     m_saliency = 0.0;
+    m_value = 0.0;
     m_present = 0.0;
     m_objectarea = ObjectArea::NOTREACHABLE;
 
@@ -52,6 +53,7 @@ Object::Object(const Object &b):Entity(b)
     this->m_present = b.m_present;
     this->m_saliency = b.m_saliency;
     this->m_objectarea = b.m_objectarea;
+    this->m_value = b.m_value;
 }
 
 Bottle Object::asBottle()
@@ -124,6 +126,10 @@ Bottle Object::asBottle()
     bSub.addDouble(m_saliency);
     b.addList() = bSub;
     bSub.clear();
+    bSub.addString(EFAA_OPC_OBJECT_VALUE);
+    bSub.addDouble(m_value);
+    b.addList() = bSub;
+    bSub.clear();
 
     //Present
     bSub.addString(EFAA_OPC_OBJECT_PRESENT_TAG);
@@ -177,6 +183,7 @@ bool Object::fromBottle(const Bottle &b)
     m_color[1] = b.find(EFAA_OPC_OBJECT_GUI_COLOR_G).asDouble();
     m_color[2] = b.find(EFAA_OPC_OBJECT_GUI_COLOR_B).asDouble();
     m_saliency = b.find(EFAA_OPC_OBJECT_SALIENCY).asDouble();
+    m_value = b.find(EFAA_OPC_OBJECT_VALUE).asDouble();
     m_present = b.find(EFAA_OPC_OBJECT_PRESENT_TAG).asDouble();
     m_objectarea = static_cast<ObjectArea>(b.find("object_area").asInt());
 
@@ -197,6 +204,8 @@ string Object::toString()
     oss<< m_color.toString(3,3)<<endl;
     oss<<"saliency : \t";
     oss<< m_saliency<<endl;
+    oss<<"value : \t";
+    oss<< m_value<<endl;
     oss<<"present : \t";
     oss<< m_present<<endl;
     oss<<"object area : \t";

--- a/main/src/libraries/wrdac/src/knowledge/object.cpp
+++ b/main/src/libraries/wrdac/src/knowledge/object.cpp
@@ -166,6 +166,7 @@ bool Object::fromBottle(const Bottle &b)
         !b.check(EFAA_OPC_OBJECT_PRESENT_TAG) ||
         !b.check("object_area")
        )
+        !b.check(EFAA_OPC_OBJECT_VALUE))
     {
         return false;
     }

--- a/main/src/modules/reactiveLayer/behaviorManager/include/dummy.h
+++ b/main/src/modules/reactiveLayer/behaviorManager/include/dummy.h
@@ -23,7 +23,7 @@ private:
 
     void run(Bottle args=Bottle()) {
         yDebug() << "Dummmy::run start " + behaviorName;
-        Time::delay(10);
+        Time::delay(4);
         yDebug() << "Dummmy::run stop " + behaviorName;
     }
     int id;

--- a/main/src/modules/reactiveLayer/behaviorManager/src/behaviorManager.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/behaviorManager.cpp
@@ -77,7 +77,6 @@ bool BehaviorManager::configure(yarp::os::ResourceFinder &rf)
         Time::delay(1.0);
     }
 
-
     if (rf.check("use_ears",Value("false")).asBool())
     {
         while (!Network::connect("/ears/behavior:o", rpc_in_port.getName())) {

--- a/main/src/modules/reactiveLayer/behaviorManager/src/behaviorManager.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/behaviorManager.cpp
@@ -77,7 +77,6 @@ bool BehaviorManager::configure(yarp::os::ResourceFinder &rf)
         Time::delay(1.0);
     }
     if (rf.check("use_ears",Value("false")).asBool())
-
     {
         while (!Network::connect("/ears/behavior:o", rpc_in_port.getName())) {
             yWarning() << "Ears is not reachable";

--- a/main/src/modules/reactiveLayer/behaviorManager/src/behaviorManager.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/behaviorManager.cpp
@@ -76,8 +76,8 @@ bool BehaviorManager::configure(yarp::os::ResourceFinder &rf)
         yInfo() << "iCubClient : Some dependencies are not running...";
         Time::delay(1.0);
     }
-
     if (rf.check("use_ears",Value("false")).asBool())
+
     {
         while (!Network::connect("/ears/behavior:o", rpc_in_port.getName())) {
             yWarning() << "Ears is not reachable";

--- a/main/src/modules/reactiveLayer/homeostasis/include/homeostasisManagerIcub.h
+++ b/main/src/modules/reactiveLayer/homeostasis/include/homeostasisManagerIcub.h
@@ -21,6 +21,10 @@ private:
     std::string moduleName;
     double period;
 
+    double stress;
+    yarp::os::BufferedPort<yarp::os::Bottle> stressPort;
+
+
     //vector< yarp::os::BufferedPort<yarp::os::Bottle> *> output_ports;
     //vector< yarp::os::BufferedPort<yarp::os::Bottle> *> input_ports;
     vector< yarp::os::BufferedPort<Bottle> * > input_ports;

--- a/main/src/modules/reactiveLayer/homeostasis/include/homeostasisManagerIcub.h
+++ b/main/src/modules/reactiveLayer/homeostasis/include/homeostasisManagerIcub.h
@@ -20,13 +20,12 @@ private:
 
     std::string moduleName;
     double period;
+    double stress_k, stress_th;
 
-    double stress;
+    //double stress;
     yarp::os::BufferedPort<yarp::os::Bottle> stressPort;
 
 
-    //vector< yarp::os::BufferedPort<yarp::os::Bottle> *> output_ports;
-    //vector< yarp::os::BufferedPort<yarp::os::Bottle> *> input_ports;
     vector< yarp::os::BufferedPort<Bottle> * > input_ports;
     vector< yarp::os::BufferedPort<Bottle> * > outputM_ports;
     vector< yarp::os::BufferedPort<Bottle> * > outputm_ports;
@@ -39,13 +38,8 @@ private:
     bool addNewDrive(string driveName, yarp::os::Bottle& grpHomeostatic);
     bool addNewDrive(string driveName);
     bool removeDrive(int d);
-    //bool addNewDrive(string driveName, yarp::os::Value grpHomeostatic, int d);
-    //void configureTactile(yarp::os::ResourceFinder &rf);
-    //void configureSalutation(yarp::os::ResourceFinder &rf);
 
 public:
-
-    //homeostaticModule():manager(0){;}
 
     Drive bDrive(yarp::os::Bottle* b)
     {

--- a/main/src/modules/reactiveLayer/homeostasis/src/homeostasisManagerIcub.cpp
+++ b/main/src/modules/reactiveLayer/homeostasis/src/homeostasisManagerIcub.cpp
@@ -481,7 +481,6 @@ bool HomeostaticModule::updateModule()
     }
     Bottle& output=stressPort.prepare();
     output.clear();
-    output.addDouble(stress);
     double k = 15.;
     double th = -0.55;
     stress = 1./(1.+exp(-k*(-stress+th)));

--- a/main/src/modules/reactiveLayer/sensationManager/include/opcSensation.h
+++ b/main/src/modules/reactiveLayer/sensationManager/include/opcSensation.h
@@ -25,7 +25,8 @@ private:
     yarp::os::BufferedPort<Bottle> opc_has_known_port;
     yarp::os::BufferedPort<Bottle> opc_has_agent_port;
     yarp::os::BufferedPort<Bottle> is_touched_port;
-
+    yarp::os::BufferedPort<Bottle>  pf3dTrackerPort;
+    yarp::os::BufferedPort<yarp::os::Bottle> outputPPSPort;
     void addToEntityList(yarp::os::Bottle& list, std::string type, std::string name);
     Bottle handleEntities();
     void handleTouch();

--- a/main/src/modules/reactiveLayer/sensationManager/include/opcSensation.h
+++ b/main/src/modules/reactiveLayer/sensationManager/include/opcSensation.h
@@ -53,5 +53,9 @@ public:
         opc_has_agent_port.close();
         is_touched_port.interrupt();
         is_touched_port.close();
+        pf3dTrackerPort.interrupt();
+        pf3dTrackerPort.close();
+        outputPPSPort.interrupt();
+        outputPPSPort.close();
     }
 };

--- a/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
@@ -199,6 +199,37 @@ Bottle OpcSensation::handleEntities()
                     yDebug("Updated OPC...");
                 }
                 addToEntityList(temp_k_entities, entity->entity_type(), entity->name());
+                Object* obj1 = iCub->opc->addOrRetrieveEntity<Object>(entity->name());
+                if (obj1->m_present == 1.0){
+                    if (entity->name() == "red_ball"){ 
+                        //change color to red
+                        obj1->m_color[0] = 250;
+                        obj1->m_color[1] = 0;
+                        obj1->m_color[2] = 0;
+                    }   
+                    //send data to PPS
+                    Bottle objec;
+                    objec.clear();
+                    objec.addDouble(obj1->m_ego_position[0]);          //X
+                    objec.addDouble(obj1->m_ego_position[1]);          //Y
+                    objec.addDouble(obj1->m_ego_position[2]);          //Z
+                    double dimensions = 0.07;//sqrt(pow(obj1->m_dimensions[0],2) + pow(obj1->m_dimensions[1],2) + pow(obj1->m_dimensions[2],2));
+                    objec.addDouble(dimensions);                       //RADIUS
+                    objec.addDouble(min(obj1->m_value,0.0)*(-1.0));    //Threat: Only negative part of value!
+                    objects.addList()=objec;
+                    yDebug("message sent");
+                }else{
+                    if (entity->name() == "red_ball"){
+                        yDebug("RedBall is present...");
+                        //change color to grey
+                        obj1->m_color[0] = 20;
+                        obj1->m_color[1] = 20;
+                        obj1->m_color[2] = 20;
+                    }
+                }
+                yDebug("Updating OPC...");
+                iCub->opc->commit(obj1);
+                yDebug("Updated OPC...");
 
             }
         }

--- a/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
@@ -7,13 +7,9 @@ void OpcSensation::configure()
     bool isRFVerbose = false;
     iCub = new ICubClient(moduleName,"sensation","client.ini",isRFVerbose);
     iCub->opc->isVerbose = false;
-    char rep = 'n';
-    while (rep!='y'&&!iCub->connect())
+    while (!iCub->connect())
     {
         cout<<"iCubClient : Some dependencies are not running..."<<endl;
-        //cout<<"Continue? y,n"<<endl;
-        //cin>>rep;
-        break; //to debug
         Time::delay(1.0);
     }
 

--- a/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
@@ -143,7 +143,6 @@ Bottle OpcSensation::handleEntities()
 
                 //Handle red balls
                 if (entity->name() == "red_ball"){
-                    yDebug("Found a redBall object");
                     // Set color:
                     obj1->m_color[0] = 250;
                     obj1->m_color[1] = 0;
@@ -152,10 +151,8 @@ Bottle OpcSensation::handleEntities()
                         yDebug("RedBall Port not connected...");
                         obj1->m_present = 0.0;
                     }else{
-                        yDebug("RedBall Port connected...\nUpdateing position...");
                         //update position
                         Bottle *bot = pf3dTrackerPort.read();
-                        yDebug("RedBall Port readed");
                         obj1->m_ego_position[0] = bot->get(0).asDouble();
                         obj1->m_ego_position[1] = bot->get(1).asDouble();
                         obj1->m_ego_position[2] = bot->get(2).asDouble();
@@ -179,13 +176,10 @@ Bottle OpcSensation::handleEntities()
                     objec.addDouble(dimensions);                       //RADIUS
                     objec.addDouble(min(obj1->m_value,0.0)*(-1.0));    //Threat: Only negative part of value!
                     objects.addList()=objec;
-                    yDebug("message sent");
                     addToEntityList(temp_kp_entities, entity->entity_type(), entity->name());
                 }
                 addToEntityList(temp_k_entities, entity->entity_type(), entity->name());
-                yDebug("Updating OPC...");
                 iCub->opc->commit(obj1);
-                yDebug("Updated OPC...");
 
                 
             }
@@ -202,11 +196,9 @@ Bottle OpcSensation::handleEntities()
         }
     }
 
-    //yDebug() << "u_entities = " + u_entities.toString();
-    //yDebug() << "k_entities = " + k_entities.toString();
+
     u_entities.copy( temp_u_entities);
     k_entities.copy( temp_k_entities);
-    yDebug()<<k_entities.toString();
     p_entities.copy( temp_p_entities);
     up_entities.copy( temp_up_entities);
     kp_entities.copy( temp_kp_entities);
@@ -228,11 +220,9 @@ Bottle OpcSensation::handleEntities()
 int OpcSensation::get_property(string name,string property)
 {
     Bottle b;
-    yDebug()<<property;
     if (property == "known")
     {
         b = k_entities;
-        yDebug()<<"Bottle: "<<b.toString();
     }
     else if (property == "unknown")
     {
@@ -242,8 +232,6 @@ int OpcSensation::get_property(string name,string property)
     {
         b = p_entities;
     }
-    yDebug()<<b.toString()<<"    " << name;
-
     for (int i=0;i<b.size();i++)
     {
         if (b.get(i).asList()->get(1).asString()==name)

--- a/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
@@ -145,37 +145,34 @@ Bottle OpcSensation::handleEntities()
                 if (dynamic_cast<Object*>(entity)->m_present == 1.0) {  // Known entities and present!
                     known_obj = true;
                     addToEntityList(temp_kp_entities, entity->entity_type(), entity->name());
-
-                    //Handle red balls
-                    if (entity->name() == "red_ball"){
-                        yDebug("Found a redBall object");
-                        if (!Network::isConnected("/pf3dTracker/data:o",("/"+moduleName+"/pf3dTracker:i").c_str())){
-                            yDebug("RedBall Port not connected...");
-                            dynamic_cast<Object*>(entity)->m_present = 0.0;
-                        }else{
-                            yDebug("RedBall Port connected...\nUpdateing position...");
-                            //update position
-                            Bottle *bot = pf3dTrackerPort.read();
-                            yDebug("RedBall Port readed");
-                            Object* obj1 = iCub->opc->addOrRetrieveEntity<Object>("red_ball");
-                            obj1->m_ego_position[0] = bot->get(0).asDouble();
-                            obj1->m_ego_position[1] = bot->get(1).asDouble();
-                            obj1->m_ego_position[2] = bot->get(2).asDouble();
-                            obj1->m_dimensions[0] = bot->get(3).asDouble();
-                            obj1->m_dimensions[1] = bot->get(4).asDouble();
-                            obj1->m_dimensions[2] = bot->get(5).asDouble();
-                            obj1->m_present = bot->get(6).asDouble();
-                            iCub->opc->commit(obj1);
-                            yDebug("opc updated...");
-                        }
+                    Object* obj1 = dynamic_cast<Object*>(entity);
+                //Handle red balls
+                if (entity->name() == "red_ball"){
+                    yDebug("Found a redBall object");
+                    // Set color:
+                    obj1->m_color[0] = 250;
+                    obj1->m_color[1] = 0;
+                    obj1->m_color[2] = 0;
+                    if (!Network::isConnected("/pf3dTracker/data:o",("/"+moduleName+"/pf3dTracker:i").c_str())){
+                        yDebug("RedBall Port not connected...");
+                        obj1->m_present = 0.0;
+                    }else{
+                        yDebug("RedBall Port connected...\nUpdateing position...");
+                        //update position
+                        Bottle *bot = pf3dTrackerPort.read();
+                        yDebug("RedBall Port readed");
+                        obj1->m_ego_position[0] = bot->get(0).asDouble();
+                        obj1->m_ego_position[1] = bot->get(1).asDouble();
+                        obj1->m_ego_position[2] = bot->get(2).asDouble();
+                        obj1->m_dimensions[0] = bot->get(3).asDouble();
+                        obj1->m_dimensions[1] = bot->get(4).asDouble();
+                        obj1->m_dimensions[2] = bot->get(5).asDouble();
+                        obj1->m_present = bot->get(6).asDouble();
+                        /*iCub->opc->commit(obj1);
+                        yDebug("opc updated...");*/
+                        
                     }
-                    Object* obj1 = iCub->opc->addOrRetrieveEntity<Object>(entity->name());
                     if (obj1->m_present == 1.0){
-                        yDebug("RedBall is present...");
-                        //change color to red
-                        obj1->m_color[0] = 250;
-                        obj1->m_color[1] = 0;
-                        obj1->m_color[2] = 0;
                         //send data to PPS
                         Bottle objec;
                         objec.clear();
@@ -187,46 +184,10 @@ Bottle OpcSensation::handleEntities()
                         objec.addDouble(min(obj1->m_value,0.0)*(-1.0));    //Threat: Only negative part of value!
                         objects.addList()=objec;
                         yDebug("message sent");
-                    }else{
-                        yDebug("RedBall is present...");
-                        //change color to grey
-                        obj1->m_color[0] = 20;
-                        obj1->m_color[1] = 20;
-                        obj1->m_color[2] = 20;
                     }
-                    yDebug("Updating OPC...");
-                    iCub->opc->commit(obj1);
-                    yDebug("Updated OPC...");
+                    
                 }
                 addToEntityList(temp_k_entities, entity->entity_type(), entity->name());
-                Object* obj1 = iCub->opc->addOrRetrieveEntity<Object>(entity->name());
-                if (obj1->m_present == 1.0){
-                    if (entity->name() == "red_ball"){ 
-                        //change color to red
-                        obj1->m_color[0] = 250;
-                        obj1->m_color[1] = 0;
-                        obj1->m_color[2] = 0;
-                    }   
-                    //send data to PPS
-                    Bottle objec;
-                    objec.clear();
-                    objec.addDouble(obj1->m_ego_position[0]);          //X
-                    objec.addDouble(obj1->m_ego_position[1]);          //Y
-                    objec.addDouble(obj1->m_ego_position[2]);          //Z
-                    double dimensions = 0.07;//sqrt(pow(obj1->m_dimensions[0],2) + pow(obj1->m_dimensions[1],2) + pow(obj1->m_dimensions[2],2));
-                    objec.addDouble(dimensions);                       //RADIUS
-                    objec.addDouble(min(obj1->m_value,0.0)*(-1.0));    //Threat: Only negative part of value!
-                    objects.addList()=objec;
-                    yDebug("message sent");
-                }else{
-                    if (entity->name() == "red_ball"){
-                        yDebug("RedBall is present...");
-                        //change color to grey
-                        obj1->m_color[0] = 20;
-                        obj1->m_color[1] = 20;
-                        obj1->m_color[2] = 20;
-                    }
-                }
                 yDebug("Updating OPC...");
                 iCub->opc->commit(obj1);
                 yDebug("Updated OPC...");

--- a/main/src/modules/reactiveLayer/sensationManager/src/sensationManager.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/sensationManager.cpp
@@ -22,20 +22,26 @@ bool SensationManager::configure(yarp::os::ResourceFinder &rf)
     period = rf.check("period",Value(0.1)).asDouble();
 
     Bottle grp = rf.findGroup("SENSATIONS");
-    sensationList = *grp.find("sensations").asList();  
-    for (int i = 0; i < sensationList.size(); i++)
-    {
-        string sensation_name = sensationList.get(i).asString();
-        // behavior_names.push_back(behavior_name);
-        if (sensation_name == "opcSensation") {
-            sensations.push_back(new OpcSensation());
-        } else if (sensation_name == "test") {
-            sensations.push_back(new Test());
-        } else{
-            yDebug() << "Sensation " + sensation_name + " not implemented";
-            return false;
+
+    if (!grp.isNull()){
+        Bottle sensationList = *grp.find("sensations").asList();  
+        for (int i = 0; i < sensationList.size(); i++)
+        {
+            string sensation_name = sensationList.get(i).asString();
+            // behavior_names.push_back(behavior_name);
+            if (sensation_name == "opcSensation") {
+                sensations.push_back(new OpcSensation());
+            } else if (sensation_name == "test") {
+                sensations.push_back(new Test());
+            } else{
+                yDebug() << "Sensation " + sensation_name + " not implemented";
+                return false;
+            }
+            sensations.back()->configure();
         }
-        sensations.back()->configure();
+    }else{
+        yError()<<"Didn't find any sensation. Please revise your configuration files...";
+        return 0;
     }
 
     // for(std::vector<Behavior*>::iterator it = behaviors.begin(); it != behaviors.end(); ++it) {

--- a/main/src/modules/reactiveLayer/sensationManager/src/sensationManager.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/sensationManager.cpp
@@ -22,9 +22,8 @@ bool SensationManager::configure(yarp::os::ResourceFinder &rf)
     period = rf.check("period",Value(0.1)).asDouble();
 
     Bottle grp = rf.findGroup("SENSATIONS");
-
     if (!grp.isNull()){
-        Bottle sensationList = *grp.find("sensations").asList();  
+        sensationList = *grp.find("sensations").asList();  
         for (int i = 0; i < sensationList.size(); i++)
         {
             string sensation_name = sensationList.get(i).asString();
@@ -66,7 +65,7 @@ bool SensationManager::updateModule()
 
 bool SensationManager::respond(const Bottle& cmd, Bottle& reply)
 {
-    yInfo() << "RPC received in allostaticController";
+    yInfo() << "RPC received in sensationsManager";
     yDebug() << cmd.toString();
     
     reply.clear();
@@ -78,6 +77,7 @@ bool SensationManager::respond(const Bottle& cmd, Bottle& reply)
     }
     else if (cmd.get(0).asString() == "is") {
         string entity_name = cmd.get(1).asString();
+
         for (int i = 0; i < sensationList.size(); i++)
         {
             string sensation_name = sensationList.get(i).asString();

--- a/main/src/modules/tools/opcPopulater/include/opcPopulater.h
+++ b/main/src/modules/tools/opcPopulater/include/opcPopulater.h
@@ -46,6 +46,7 @@ public:
 
     bool    addUnknownEntity(Bottle bInput);
     bool    setSaliencyEntity(Bottle bInput);
+    bool    setValueEntity(Bottle bInput);
 
     bool    populateABM(Bottle bInput);
     bool    populateABMiCubStory(Bottle bInput);

--- a/main/src/modules/tools/opcPopulater/include/opcPopulater.h
+++ b/main/src/modules/tools/opcPopulater/include/opcPopulater.h
@@ -19,6 +19,11 @@ private:
     double Y_ag;
     double Z_ag;
     double noise;
+    vector<double> spd1;
+    vector<double> spd2;
+    bool move;
+    int iter;
+
 
 
 public:
@@ -39,6 +44,8 @@ public:
 
     bool updateModule();
     bool    populateEntityRandom(Bottle bInput);
+    bool    populateRedBall();
+    bool    populateMoving();
     bool    populateSpecific();
     bool    populateSpecific1(Bottle bInput);
     bool    populateSpecific2();

--- a/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
+++ b/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
@@ -184,12 +184,18 @@ bool opcPopulater::updateModule() {
             spd2[1]/=av2;
             spd2[2]/=av2;
         }
-        obj1->m_ego_position[0] = min(max(obj1->m_ego_position[0]+spd1[0]*period*speed,-0.2),-0.5);
+       /* obj1->m_ego_position[0] = min(max(obj1->m_ego_position[0]+spd1[0]*period*speed,-0.2),-0.5);
         obj1->m_ego_position[1] = min(max(obj1->m_ego_position[1]+spd1[1]*period*speed,0.0),0.5);
         obj1->m_ego_position[2] = min(max(obj1->m_ego_position[2]+spd1[2]*period*speed,0.0),0.5);
         obj2->m_ego_position[0] = min(max(obj2->m_ego_position[0]+spd2[0]*period*speed,-0.2),-0.5);
         obj2->m_ego_position[1] = min(max(obj2->m_ego_position[1]+spd2[1]*period*speed,0.0),0.5);
-        obj2->m_ego_position[2] = min(max(obj2->m_ego_position[2]+spd2[2]*period*speed,0.0),0.5);
+        obj2->m_ego_position[2] = min(max(obj2->m_ego_position[2]+spd2[2]*period*speed,0.0),0.5);*/
+        obj1->m_ego_position[0] = -0.18;
+        obj1->m_ego_position[1] = 0.10;
+        obj1->m_ego_position[2] = 0.1;
+        obj2->m_ego_position[0] = -0.18;
+        obj2->m_ego_position[1] = -0.10;
+        obj2->m_ego_position[2] = 0.1;
         iCub->opc->commit(obj1);
         iCub->opc->commit(obj2);
 

--- a/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
+++ b/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
@@ -866,7 +866,7 @@ bool opcPopulater::populateMoving(){
     obj2->m_color[0] = Random::uniform(100, 180);
     obj2->m_color[1] = Random::uniform(0, 80);
     obj2->m_color[2] = Random::uniform(180, 250);
-    obj1->m_value = -1.0;
+    obj2->m_value = -1.0;
     iCub->opc->commit(obj2);
 
     move=true;

--- a/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
+++ b/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
@@ -389,32 +389,15 @@ bool opcPopulater::setValueEntity(Bottle bInput){
     double targetValue = bInput.get(2).asDouble();
 
     iCub->opc->checkout();
-    list<Entity*> lEntities = iCub->opc->EntitiesCache();
 
-    for (list<Entity*>::iterator itEnt = lEntities.begin(); itEnt != lEntities.end(); itEnt++)
-    {
-        if ((*itEnt)->name() == sName)
-        {
-            if ((*itEnt)->entity_type() == "agent")
-            {
-                Agent* temp = dynamic_cast<Agent*>(*itEnt);
-                temp->m_value = targetValue;
-            }
-            if ((*itEnt)->entity_type() == "object")
-            {
-                Object* temp = dynamic_cast<Object*>(*itEnt);
-                temp->m_value = targetValue;
-            }
-            if ((*itEnt)->entity_type() == "rtobject")
-            {
-                RTObject* temp = dynamic_cast<RTObject*>(*itEnt);
-                temp->m_value = targetValue;
-            }
-        }
+    Entity *e = iCub->opc->getEntity(sName);
+    if (e && (e->entity_type() == "agent" || e->entity_type() == "object" || e->entity_type() == "rtobject")) {
+        Object* temp = dynamic_cast<Object*>(e);
+        temp->m_value = targetValue;
+        iCub->opc->commit();
+    }else{
+        yWarning()<<"Trying to change value of the non-object entity: "<<sName<<". Please check!";
     }
-
-    iCub->opc->commit();
-
     return true;
 }
 

--- a/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
+++ b/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
@@ -196,13 +196,13 @@ bool opcPopulater::updateModule() {
         obj2->m_ego_position[0] = -0.18;
         obj2->m_ego_position[1] = -0.10;
         obj2->m_ego_position[2] = 0.1;
+
         iCub->opc->commit(obj1);
         iCub->opc->commit(obj2);
 
         iter += 1;
     }
     return true;
-    
 }
 
 bool opcPopulater::populateEntityRandom(Bottle bInput){
@@ -854,9 +854,10 @@ bool opcPopulater::populateMoving(){
     iCub->opc->clear();
 
     Object* obj1 = iCub->opc->addOrRetrieveEntity<Object>("moving_1");
-    obj1->m_ego_position[0] = -0.3;
-    obj1->m_ego_position[1] = 0.05;
-    obj1->m_ego_position[2] = 0;
+    obj1->m_ego_position[0] = -0.18;
+    obj1->m_ego_position[1] = 0.10;
+    obj1->m_ego_position[2] = 0.1;
+
     obj1->m_present = 1.0;
     obj1->m_color[0] = 20;
     obj1->m_color[1] = 20;
@@ -865,9 +866,10 @@ bool opcPopulater::populateMoving(){
     iCub->opc->commit(obj1);
 
     Object* obj2 = iCub->opc->addOrRetrieveEntity<Object>("moving_2");
-    obj2->m_ego_position[0] = -0.3;
-    obj2->m_ego_position[1] = -0.05;
-    obj2->m_ego_position[2] = 0;
+    obj2->m_ego_position[0] = -0.18;
+    obj2->m_ego_position[1] = -0.10;
+    obj2->m_ego_position[2] = 0.1;
+
     obj2->m_present = 1.0;
     obj2->m_color[0] = 200;
     obj2->m_color[1] = 20;

--- a/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
+++ b/main/src/modules/tools/opcPopulater/src/opcPopulater.cpp
@@ -854,28 +854,28 @@ bool opcPopulater::populateMoving(){
     iCub->opc->clear();
 
     Object* obj1 = iCub->opc->addOrRetrieveEntity<Object>("moving_1");
-    obj1->m_ego_position[0] = -0.4;
-    obj1->m_ego_position[1] = 0.25;
+    obj1->m_ego_position[0] = -0.3;
+    obj1->m_ego_position[1] = 0.05;
     obj1->m_ego_position[2] = 0;
     obj1->m_present = 1.0;
-    obj1->m_color[0] = Random::uniform(0, 80);
-    obj1->m_color[1] = Random::uniform(80, 180);
-    obj1->m_color[2] = Random::uniform(180, 250);
+    obj1->m_color[0] = 20;
+    obj1->m_color[1] = 20;
+    obj1->m_color[2] = 20;
     obj1->m_value = 0.0;
     iCub->opc->commit(obj1);
 
     Object* obj2 = iCub->opc->addOrRetrieveEntity<Object>("moving_2");
-    obj2->m_ego_position[0] = -0.4;
-    obj2->m_ego_position[1] = -0.25;
+    obj2->m_ego_position[0] = -0.3;
+    obj2->m_ego_position[1] = -0.05;
     obj2->m_ego_position[2] = 0;
     obj2->m_present = 1.0;
-    obj2->m_color[0] = Random::uniform(100, 180);
-    obj2->m_color[1] = Random::uniform(0, 80);
-    obj2->m_color[2] = Random::uniform(180, 250);
+    obj2->m_color[0] = 200;
+    obj2->m_color[1] = 20;
+    obj2->m_color[2] = 20;
     obj2->m_value = -1.0;
     iCub->opc->commit(obj2);
 
-    move=true;
+    //move=true;
 
 
     return true;


### PR DESCRIPTION
This is the `ReactiveLayer` component of the `pps-value` integration. Principal changes involving:

- `homeostasisManager` now signals stress and can be set to different update-rates from the config file. 
- `opcSensations` now relays the value of objects. 
- `opcPopulater` can populate moving objects and objects with some positive or negative 'valence'. 
- `icubClient/wrdac` now includes value as an additional variable of `objects`. Default is set to 0. There's no need to specify it on entity creation. There is no change on the behavior of `opc`, `entity` query, etc. And no change is needed in other modules that don't require the use of value. 
- specific config files have been created for testing. To test, run reactive layer modules with `--from pps.ini`. 
- corresponding scripts have been added to `main/apps`. 

rebased `devel` on 06/09/2016

Contact me for any additional detail. 