### PR TITLE
Fix/goals

### DIFF
--- a/main/app/contextualLayer/planner/conf/client.ini
+++ b/main/app/contextualLayer/planner/conf/client.ini
@@ -1,1 +1,1 @@
-subsystems				(abm)		
+subsystems              (abm)

--- a/main/app/contextualLayer/planner/conf/client.ini
+++ b/main/app/contextualLayer/planner/conf/client.ini
@@ -1,1 +1,1 @@
-subsystems				()		
+subsystems				(abm)		

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -1,16 +1,16 @@
-fulfill					true
-ears					true
-homeostasis				true
+fulfill                 true
+ears                    true
+homeostasis             true
 
 
 [PLANS]
 plans   (point dum narrate object_give object_take)
 
 point-totactions                 2
-point-action1                    (tagging	_obj)
+point-action1                    (tagging   _obj)
 point-1pre                       ( ((not) (is _obj known)) (() (is any present)) )
 point-1post                      ( (() (is _obj known)) (() (is _obj present)) )
-point-action2                    (pointing	_obj)
+point-action2                    (pointing  _obj)
 point-2pre                       ( (() (is _obj known)) (() (is _obj present)) )
 point-2post                      ( (() (is _obj known)) (() (is _obj present)) )
 
@@ -23,7 +23,7 @@ dum-2pre                         ( (() (is mug known)))
 dum-2post                        ( (() (is mug known)))
 
 narrate-totactions               1
-narrate-action1                  (narrate	_obj)
+narrate-action1                  (narrate   _obj)
 narrate-1pre                     ( )
 narrate-1post                    ( )
 

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -1,4 +1,3 @@
-[SETTINGS]
 fulfill					true
 ears					false
 homeostasis				false

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -1,35 +1,35 @@
 
 [PLANS]
-plans   (pointmug dum object_give object_take)
+plans   (point dum object_give object_take)
 
-pointmug-totactions                 2
-pointmug-action1                    tagging
-pointmug-1pre                       ( ((not) (is mug known)) (() (is any present)) )
-pointmug-1post                      ( (() (is mug known)) (() (is mug present)) )
-pointmug-action2                    pointing
-pointmug-2pre                       ( (() (is mug known)) (() (is mug present)) )
-pointmug-2post                      ( (() (is mug known)) (() (is mug present)) )
+point-totactions                 2
+point-action1                    (tagging	_obj)
+point-1pre                       ( ((not) (is _obj known)) (() (is any present)) )
+point-1post                      ( (() (is _obj known)) (() (is _obj present)) )
+point-action2                    (pointing	_obj)
+point-2pre                       ( (() (is _obj known)) (() (is _obj present)) )
+point-2post                      ( (() (is _obj known)) (() (is _obj present)) )
 
 dum-totactions                         2
-dum-action1                         dummy
+dum-action1                         (dummy)
 dum-1pre                            ( ((not) (is mug known)))
 dum-1post                           ( (() (is mug known)))
-dum-action2                         dummy2
+dum-action2                         (dummy2)
 dum-2pre                            ( (() (is mug known)))
 dum-2post                           ( (() (is mug known)))
 
 object_give-totactions              2
-object_give-action1                 push
+object_give-action1                 (push)
 object_give-1pre                    ( (() (is any I)) )
 object_give-1post                   ( (() (is any B)) )
-object_give-action2                 ask_pull
+object_give-action2                 (ask_pull)
 object_give-2pre                    ( (() (is any B)) )
 object_give-2post                   ( (() (is any H)) )
 
 object_take-totactions              2
-object_take-action1                 ask_push
+object_take-action1                 (ask_push)
 object_take-1pre                    ( (() (is any H)) )
 object_take-1post                   ( (() (is any B)) )
-object_take-action2                 pull
+object_take-action2                 (pull)
 object_take-2pre                    ( (() (is any B)) )
 object_take-2post                   ( (() (is any I)) )

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -1,3 +1,8 @@
+[SETTINGS]
+fulfill					true
+ears					false
+homeostasis				false
+
 
 [PLANS]
 plans   (point dum object_give object_take)

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -1,10 +1,10 @@
 fulfill					true
-ears					false
-homeostasis				false
+ears					true
+homeostasis				true
 
 
 [PLANS]
-plans   (point dum object_give object_take)
+plans   (point dum narrate object_give object_take)
 
 point-totactions                 2
 point-action1                    (tagging	_obj)
@@ -14,26 +14,31 @@ point-action2                    (pointing	_obj)
 point-2pre                       ( (() (is _obj known)) (() (is _obj present)) )
 point-2post                      ( (() (is _obj known)) (() (is _obj present)) )
 
-dum-totactions                         2
-dum-action1                         (dummy)
-dum-1pre                            ( ((not) (is mug known)))
-dum-1post                           ( (() (is mug known)))
-dum-action2                         (dummy2)
-dum-2pre                            ( (() (is mug known)))
-dum-2post                           ( (() (is mug known)))
+dum-totactions                   2
+dum-action1                      (dummy)
+dum-1pre                         ( ((not) (is mug known)))
+dum-1post                        ( (() (is mug known)))
+dum-action2                      (dummy2)
+dum-2pre                         ( (() (is mug known)))
+dum-2post                        ( (() (is mug known)))
 
-object_give-totactions              2
-object_give-action1                 (push)
-object_give-1pre                    ( (() (is any I)) )
-object_give-1post                   ( (() (is any B)) )
-object_give-action2                 (ask_pull)
-object_give-2pre                    ( (() (is any B)) )
-object_give-2post                   ( (() (is any H)) )
+narrate-totactions               1
+narrate-action1                  (narrate	_obj)
+narrate-1pre                     ( )
+narrate-1post                    ( )
 
-object_take-totactions              2
-object_take-action1                 (ask_push)
-object_take-1pre                    ( (() (is any H)) )
-object_take-1post                   ( (() (is any B)) )
-object_take-action2                 (pull)
-object_take-2pre                    ( (() (is any B)) )
-object_take-2post                   ( (() (is any I)) )
+object_give-totactions           2
+object_give-action1              (push)
+object_give-1pre                 ( (() (is any I)) )
+object_give-1post                ( (() (is any B)) )
+object_give-action2              (ask_pull)
+object_give-2pre                 ( (() (is any B)) )
+object_give-2post                ( (() (is any H)) )
+
+object_take-totactions           2
+object_take-action1              (ask_push)
+object_take-1pre                 ( (() (is any H)) )
+object_take-1post                ( (() (is any B)) )
+object_take-action2              (pull)
+object_take-2pre                 ( (() (is any B)) )
+object_take-2post                ( (() (is any I)) )

--- a/main/app/reactiveLayer/behaviorManager/conf/default.ini
+++ b/main/app/reactiveLayer/behaviorManager/conf/default.ini
@@ -3,9 +3,7 @@ use_ears        true
 [BEHAVIORS]
 
 behaviors	(tagging, pointing, narrate, followingOrder, recognitionOrder)
-
 ttsOptions      "iCub"
-
 
 [followingOrder]
 ks1 (15126)

--- a/main/src/modules/contextualLayer/planner/include/planner.h
+++ b/main/src/modules/contextualLayer/planner/include/planner.h
@@ -23,6 +23,7 @@ private:
     vector<int> priority_list;
     vector<int> actionPos_list;
     Bottle grpPlans;
+    Bottle set;
     int id;
     int attemptCnt;
 

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -419,7 +419,7 @@ bool Planner::updateModule() {
                     // insert actions into the various lists
                     if (!rankPriority)
                     {
-                        for (unsigned a = action_store.size(); a-- > 0;)
+                        for (int a = (int)action_store.size() - 1; a >= 0; a--)
                         {
                             yInfo() << "adding action " << action_store[a];
                             action_list.push_back(action_store[a]);

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -22,8 +22,11 @@ bool Planner::configure(yarp::os::ResourceFinder &rf)
     grpPlans = rf.findGroup("PLANS");
     avaiPlansList = *grpPlans.find("plans").asList();
 
-    bool ears = 0;
-    bool homeo = 0;
+    set = rf.findGroup("SETTINGS");
+    fulfill = *set.find("fulfill").asString();
+
+    bool ears = *set.find("ears").asString();
+    bool homeo = *set.find("homeostasis").asString();
     bool SM = 1;
     bool BM = 1;
 
@@ -70,7 +73,6 @@ bool Planner::configure(yarp::os::ResourceFinder &rf)
     priority_list.clear();
     action_list.clear();
     id = 0;
-    fulfill = false;
     attemptCnt = 0;
 
     yInfo() << "\n \n" << "----------------------------------------------" << "\n \n" << moduleName << " ready ! \n \n ";
@@ -340,7 +342,7 @@ bool Planner::updateModule() {
                         auxMsg.clear();
                         bool indiv;
                         bool negate;
-                        string attach = preconds.get(k).asList()->get(0).asString();
+                        string attach = preconds.get(k).asList()->get(0).toString();
                         yDebug() << preconds.toString();
                         if (attach == "not")
                         {

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -22,11 +22,10 @@ bool Planner::configure(yarp::os::ResourceFinder &rf)
     grpPlans = rf.findGroup("PLANS");
     avaiPlansList = *grpPlans.find("plans").asList();
 
-    set = rf.findGroup("SETTINGS");
-    fulfill = *set.find("fulfill").asString();
+    fulfill = rf.check("fulfill",Value("true")).asBool();
 
-    bool ears = *set.find("ears").asString();
-    bool homeo = *set.find("homeostasis").asString();
+    bool ears = rf.check("ears",Value("true")).asBool();
+    bool homeo = rf.check("homeostasis",Value("true")).asBool();
     bool SM = 1;
     bool BM = 1;
 
@@ -339,19 +338,19 @@ bool Planner::updateModule() {
                             auxMsg.addString(aux);
                         }
                         getState.write(auxMsg, rep);
+                        yDebug() << auxMsg.toString();
                         auxMsg.clear();
                         bool indiv;
                         bool negate;
                         string attach = preconds.get(k).asList()->get(0).toString();
-                        yDebug() << preconds.toString();
                         if (attach == "not")
                         {
+                            yDebug() << "not";
                             indiv = !rep.get(1).asBool();
                             negate = true;
                         }
                         else
                         {
-                            yDebug() << "attached is a non-negation";
                             indiv = rep.get(1).asBool();
                             negate = false;
                         }
@@ -592,6 +591,7 @@ bool Planner::updateModule() {
                 {
                     yInfo() << "reached threshold for action attempts.";
                     iCub->say("I have tried too many times and failed to do " + action_list[0] + ". Do it yourself or help me.");
+
                     // remove action and/or plan?
                 }
                 // wait for a second before trying again
@@ -623,6 +623,7 @@ bool Planner::triggerBehavior(Bottle cmd)
     Bottle reply;
     reply.clear();
     portToBehavior.write(cmd,reply);
+    yDebug() << "Bottle contents: " << cmd.toString();
     if (reply.get(0).asString() == "ack")
     {
         return true;

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -342,11 +342,11 @@ bool Planner::updateModule() {
                     }
 
                     // record action selection reasoning in ABM
-                    // iCub->getABMClient()->sendActivity("reasoning",
-                    //     actionName,
-                    //     "planner",  // expl: "pasar", "drives"...
-                    //     lArgument,
-                    //     true);
+                    iCub->getABMClient()->sendActivity("reasoning",
+                        actionName,
+                        "planner",  // expl: "pasar", "drives"...
+                        lArgument,
+                        true);
                     yInfo() << actionName + " reasoning has been recorded in the ABM";
 
                     if (state)
@@ -407,11 +407,11 @@ bool Planner::updateModule() {
                             lArgument.push_back(std::pair<std::string, std::string>("priority", "agent"));
                             lArgument.push_back(std::pair<std::string, std::string>(actionName, "object"));
                             lArgument.push_back(std::pair<std::string, std::string>("bottom", "result"));
-                            // iCub->getABMClient()->sendActivity("reasoning",
-                            //     "priority",
-                            //     "planner",  // expl: "pasar", "drives"...
-                            //     lArgument,
-                            //     true);
+                            iCub->getABMClient()->sendActivity("reasoning",
+                                "priority",
+                                "planner",  // expl: "pasar", "drives"...
+                                lArgument,
+                                true);
                             yInfo() << "addition of " + actionName + " to bottom of list has been recorded in the ABM";
                         }
 
@@ -437,11 +437,11 @@ bool Planner::updateModule() {
                             lArgument.push_back(std::pair<std::string, std::string>("priority", "agent"));
                             lArgument.push_back(std::pair<std::string, std::string>(actionName, "object"));
                             lArgument.push_back(std::pair<std::string, std::string>(to_string(insertID), "result"));
-                            // iCub->getABMClient()->sendActivity("reasoning",
-                            //     "priority",
-                            //     "planner",  // expl: "pasar", "drives"...
-                            //     lArgument,
-                            //     true);
+                            iCub->getABMClient()->sendActivity("reasoning",
+                                "priority",
+                                "planner",  // expl: "pasar", "drives"...
+                                lArgument,
+                                true);
                             yInfo() << "addition of " + actionName + " to index " << insertID << " of list has been recorded in the ABM";
                         }
                     }
@@ -504,11 +504,11 @@ bool Planner::updateModule() {
             {
                 lArgument.push_back(std::pair<std::string, std::string>(action_list[i], "action"));
             }
-            // iCub->getABMClient()->sendActivity("reasoning",
-            //     "action_list",
-            //     "planner",  // expl: "pasar", "drives"...
-            //     lArgument,
-            //     true);
+            iCub->getABMClient()->sendActivity("reasoning",
+                "action_list",
+                "planner",  // expl: "pasar", "drives"...
+                lArgument,
+                true);
             // yInfo() << "sent action_list to ABM";
             lArgument.clear();
 
@@ -562,11 +562,11 @@ bool Planner::updateModule() {
                 lArgument.push_back(std::pair<std::string, std::string>("keep_action", "predicate"));
                 lArgument.push_back(std::pair<std::string, std::string>("iCub", "agent"));
                 lArgument.push_back(std::pair<std::string, std::string>(action_list[0], "object"));
-                // iCub->getABMClient()->sendActivity("reasoning",
-                //     "iCub",
-                //     "planner",  // expl: "pasar", "drives"...
-                //     lArgument,
-                //     true);
+                iCub->getABMClient()->sendActivity("reasoning",
+                    "iCub",
+                    "planner",  // expl: "pasar", "drives"...
+                    lArgument,
+                    true);
                 yInfo() << action_list[0] + " failure and reattempt has been recorded in the ABM";
 
                 if (attemptCnt > 2)

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -375,13 +375,19 @@ bool Planner::updateModule() {
                         yDebug() << "lArgument formed for condition";
                     }
 
-                    record action selection reasoning in ABM
-                    iCub->getABMClient()->sendActivity("reasoning",
-                        actionName,
+                    // record action selection reasoning in ABM
+                    yDebug() << "recording in ABM";
+                    if (iCub->getABMClient()->Connect())
+                    {
+                        yDebug() << "ABM is connected";
+                        iCub->getABMClient()->sendActivity("reasoning",
+                            actionName,
                         "planner",  // expl: "pasar", "drives"...
                         lArgument,
                         true);
-                    yInfo() << actionName + " reasoning has been recorded in the ABM";
+                        yInfo() << actionName + " reasoning has been recorded in the ABM";
+                    }
+                    else { yInfo() << "ABMClient is not connected."; }
 
 
                     // insert actions into the various holding lists (IN REVERSE ORDER)
@@ -416,17 +422,21 @@ bool Planner::updateModule() {
                             actionPos_list.push_back(actionPos_store[a]);
 
                             // log in ABM
-                            std::list<std::pair<std::string, std::string> > lArgument;
-                            lArgument.push_back(std::pair<std::string, std::string>("add_action", "predicate"));
-                            lArgument.push_back(std::pair<std::string, std::string>("priority", "agent"));
-                            lArgument.push_back(std::pair<std::string, std::string>(action_store[a], "object"));
-                            lArgument.push_back(std::pair<std::string, std::string>("bottom", "result"));
-                            iCub->getABMClient()->sendActivity("reasoning",
-                                "priority",
+                            if (iCub->getABMClient()->Connect())
+                            {
+                                std::list<std::pair<std::string, std::string> > lArgument;
+                                lArgument.push_back(std::pair<std::string, std::string>("add_action", "predicate"));
+                                lArgument.push_back(std::pair<std::string, std::string>("priority", "agent"));
+                                lArgument.push_back(std::pair<std::string, std::string>(action_store[a], "object"));
+                                lArgument.push_back(std::pair<std::string, std::string>("bottom", "result"));
+                                iCub->getABMClient()->sendActivity("reasoning",
+                                    "priority",
                                 "planner",  // expl: "pasar", "drives"...
                                 lArgument,
                                 true);
-                            yInfo() << "addition of " + action_store[a] + " to bottom of list has been recorded in the ABM";
+                                yInfo() << "addition of " + action_store[a] + " to bottom of list has been recorded in the ABM";
+                            }
+                            else { yInfo() << "ABMClient is not connected."; }
                         }
                     }
                     else
@@ -442,17 +452,21 @@ bool Planner::updateModule() {
                             priority_list.insert(priority_list.begin() + insertID, priority_store[a]);
 
                             // log in ABM
-                            std::list<std::pair<std::string, std::string> > lArgument;
-                            lArgument.push_back(std::pair<std::string, std::string>("add_action", "predicate"));
-                            lArgument.push_back(std::pair<std::string, std::string>("priority", "agent"));
-                            lArgument.push_back(std::pair<std::string, std::string>(action_store[a], "object"));
-                            lArgument.push_back(std::pair<std::string, std::string>(to_string(insertID), "result"));
-                            iCub->getABMClient()->sendActivity("reasoning",
-                                "priority",
-                                "planner",  // expl: "pasar", "drives"...
-                                lArgument,
-                                true);
-                            yInfo() << "addition of " + action_store[a] + " to index" << insertID << "of list has been recorded in the ABM";
+                            if (iCub->getABMClient()->Connect())
+                            {
+                                std::list<std::pair<std::string, std::string> > lArgument;
+                                lArgument.push_back(std::pair<std::string, std::string>("add_action", "predicate"));
+                                lArgument.push_back(std::pair<std::string, std::string>("priority", "agent"));
+                                lArgument.push_back(std::pair<std::string, std::string>(action_store[a], "object"));
+                                lArgument.push_back(std::pair<std::string, std::string>(to_string(insertID), "result"));
+                                iCub->getABMClient()->sendActivity("reasoning",
+                                    "priority",
+                                    "planner",  // expl: "pasar", "drives"...
+                                    lArgument,
+                                    true);
+                                yInfo() << "addition of " + action_store[a] + " to index" << insertID << "of list has been recorded in the ABM";
+                            }
+                            else { yInfo() << "ABMClient is not connected"; }
                         }
                     }
 
@@ -598,16 +612,20 @@ bool Planner::updateModule() {
                 attemptCnt += 1;
 
                 // log in ABM
-                std::list<std::pair<std::string, std::string> > lArgument;
-                lArgument.push_back(std::pair<std::string, std::string>("keep_action", "predicate"));
-                lArgument.push_back(std::pair<std::string, std::string>("iCub", "agent"));
-                lArgument.push_back(std::pair<std::string, std::string>(action_list[0], "object"));
-                iCub->getABMClient()->sendActivity("reasoning",
-                    "iCub",
+                if (iCub->getABMClient()->Connect())
+                {
+                    std::list<std::pair<std::string, std::string> > lArgument;
+                    lArgument.push_back(std::pair<std::string, std::string>("keep_action", "predicate"));
+                    lArgument.push_back(std::pair<std::string, std::string>("iCub", "agent"));
+                    lArgument.push_back(std::pair<std::string, std::string>(action_list[0], "object"));
+                    iCub->getABMClient()->sendActivity("reasoning",
+                        "iCub",
                     "planner",  // expl: "pasar", "drives"...
                     lArgument,
                     true);
-                yInfo() << action_list[0] + " failure and reattempt has been recorded in the ABM";
+                    yInfo() << action_list[0] + " failure and reattempt has been recorded in the ABM";
+                }
+                else { yInfo() << "ABMClient is not connected."; }
 
                 if (attemptCnt > 2)
                 {

--- a/main/src/modules/reactiveLayer/behaviorManager/src/pointing.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/pointing.cpp
@@ -10,18 +10,19 @@ void Pointing::run(Bottle args/*=Bottle()*/) {
     yInfo() << "Pointing::run";
     Bottle *sensation = sensation_port_in.read();
 
-    if(sensation->size()==0) {
-        iCub->say("There are no objects I can point at.");
-        return;
-    }
     string obj_name, sentence;
     bool no_objects = true;
     if (args.size()!=0){
-        obj_name = args.get(0).asString();
+        yDebug()<<args.toString() << args.size();
+        obj_name = args.get(0).asList()->toString();
         yDebug() << "Object selected: " << obj_name;
         sentence = "Ok, this is the ";
         no_objects=false;
     }else{
+        if(sensation->size()==0) {
+            iCub->say("There are no objects I can point at.");
+            return;
+        }
         int id = yarp::os::Random::uniform(0, sensation->size() - 1);
         obj_name = sensation->get(id).asList()->get(1).asString();
         yDebug() << "Randomly selected: " << id << " " << obj_name;

--- a/main/src/modules/reactiveLayer/behaviorManager/src/pointing.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/pointing.cpp
@@ -16,7 +16,7 @@ void Pointing::run(Bottle args/*=Bottle()*/) {
         yDebug()<<args.toString() << args.size();
         obj_name = args.get(0).asList()->toString();
         yDebug() << "Object selected: " << obj_name;
-        sentence = "Ok, this is the ";
+        sentence = "Okay, this is the ";
         no_objects=false;
     }else{
         if(sensation->size()==0) {

--- a/main/src/modules/reactiveLayer/behaviorManager/src/pointing.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/pointing.cpp
@@ -14,30 +14,40 @@ void Pointing::run(Bottle args/*=Bottle()*/) {
         iCub->say("There are no objects I can point at.");
         return;
     }
+    string obj_name, sentence;
+    bool no_objects = true;
+    if (args.size()!=0){
+        obj_name = args.get(0).asString();
+        yDebug() << "Object selected: " << obj_name;
+        sentence = "Ok, this is the ";
+        no_objects=false;
+    }else{
+        int id = yarp::os::Random::uniform(0, sensation->size() - 1);
+        obj_name = sensation->get(id).asList()->get(1).asString();
+        yDebug() << "Randomly selected: " << id << " " << obj_name;
+        sentence = "I could point to the ";
+    }
     
-    int id = yarp::os::Random::uniform(0, sensation->size() - 1);
-    yDebug() << "Randomly selected: " << id;
-    string obj_name = sensation->get(id).asList()->get(1).asString();
-
     iCub->opc->checkout();
     yDebug() << "[pointing]: opc checkout";
     iCub->lookAtPartner();
     Time::delay(0.5);
     
-    iCub->say("I could point to the " + obj_name);
+    iCub->say(sentence + obj_name);
     iCub->home();
     Time::delay(1.5);
 
     bool succeeded = iCub->point(obj_name);
     Time::delay(0.2);
 
-    if (succeeded) {
-        iCub->lookAtPartner();
-        iCub->say("Do you know that this is a " + obj_name, false);
-    } else {
-        iCub->say(" I couldn't find the " + obj_name);
+    if (no_objects){
+        if (succeeded) {
+            iCub->lookAtPartner();
+            iCub->say("Do you know that this is a " + obj_name, false);
+        } else {
+            iCub->say(" I couldn't find the " + obj_name);
+        }
     }
-
     iCub->home();
 
 }

--- a/main/src/modules/reactiveLayer/behaviorManager/src/tagging.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/tagging.cpp
@@ -9,29 +9,74 @@ void Tagging::configure() {
 void Tagging::run(Bottle args/*=Bottle()*/) {
     yInfo() << "Tagging::run";
     yDebug() << "send rpc to proactiveTagging";
-    Bottle *sensation = sensation_port_in.read();
-    int id = yarp::os::Random::uniform(0, sensation->size()-1);
-
-    // If there are unknown agents, prioritise tagging it.
-    for (int i = 0; i < sensation->size(); i++)
-    {
-        string type = sensation->get(i).asList()->get(0).asString();
-        string name = sensation->get(i).asList()->get(1).asString();
-
-        if ((type == "agent") && (name == "partner"))
-        {
-            id = i;
-        }
-    }
-
-    //If there is an unknown object (to see with agents and rtobjects), add it to the rpc_command bottle, and return true
+    string type, target, sentence;
+    bool no_objects = true;
     Bottle cmd;
     Bottle rply;
-    cmd.clear();
-    cmd.addString("exploreUnknownEntity");
-    cmd.addString(sensation->get(id).asList()->get(0).asString());
-    cmd.addString(sensation->get(id).asList()->get(1).asString());
-    yInfo() << "Proactively tagging:" << cmd.toString();
+    if (args.size()!=0){
+        if(args.size()<=2){
+            yDebug()<<args.toString() << args.size();
+            target = args.get(0).asList()->toString();
+            type = args.get(1).asList()->toString();
+            yDebug() << "Object selected: " << target << "Type: "<<type;
+            list<Entity*> lEntities = iCub->opc->EntitiesCache();
+            for (auto& entity: lEntities)
+            {
+                string sName = entity->name();
+                if (sName == target) {
+                    yDebug() << "Entity found: "<<target;
+                    if (entity->entity_type() == "object")
+                    {
+                        Object* o = dynamic_cast<Object*>(iCub->opc->getEntity(sName));
+                        yInfo() << "I found the entity in the opc: " << sName;
+                        if(o && o->m_present==1.0) {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            yInfo() << "I need to explore by name!";
+
+            // ask for the object
+            yInfo() << "send rpc to proactiveTagging";
+
+            //If there is an unknown object (to see with agents and rtobjects), add it to the rpc_command bottle, and return true
+
+
+            cmd.addString("searchingEntity");
+            cmd.addString(type);
+            cmd.addString(target);
+            rpc_out_port.write(cmd,rply);
+            yDebug() << rply.toString();
+        }else{yDebug()<<"ERRORRRR!!!!! Input not valid!!";}
+    }else{
+        Bottle *sensation = sensation_port_in.read();
+        int id = yarp::os::Random::uniform(0, sensation->size()-1);
+
+        // If there are unknown agents, prioritise tagging it.
+        for (int i = 0; i < sensation->size(); i++)
+        {
+            string type = sensation->get(i).asList()->get(0).asString();
+            string target = sensation->get(i).asList()->get(1).asString();
+
+            if ((type == "agent") && (target == "partner"))
+            {
+                id = i;
+            }
+        }
+        target=sensation->get(id).asList()->get(0).asString();
+        type=sensation->get(id).asList()->get(1).asString();
+        yDebug() << "Object selected: " << target << "Type: "<<type;
+        //If there is an unknown object (to see with agents and rtobjects), add it to the rpc_command bottle, and return true
+        
+        cmd.clear();
+        cmd.addString("exploreUnknownEntity");
+        cmd.addString(target);
+        cmd.addString(type);
+        yInfo() << "Proactively tagging:" << cmd.toString();
+    }
+    
     
     rpc_out_port.write(cmd, rply);
     yInfo() << "Proactive tagging ends";

--- a/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
@@ -233,7 +233,9 @@ int OpcSensation::get_property(string name,string property)
     {
         b = p_entities;
     }
-    if (name == any){
+    if (name == "any"){
+        yDebug() << "name is any"; 
+        yDebug() << b.size();
         if (b.size()!=0){
             return 1;
         }else{
@@ -247,7 +249,7 @@ int OpcSensation::get_property(string name,string property)
                 return 1;
             }
         }
-    return 0;
+        return 0;
     }
 }
 

--- a/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
+++ b/main/src/modules/reactiveLayer/sensationManager/src/opcSensation.cpp
@@ -220,6 +220,7 @@ Bottle OpcSensation::handleEntities()
 int OpcSensation::get_property(string name,string property)
 {
     Bottle b;
+
     if (property == "known")
     {
         b = k_entities;
@@ -232,13 +233,21 @@ int OpcSensation::get_property(string name,string property)
     {
         b = p_entities;
     }
-    for (int i=0;i<b.size();i++)
-    {
-        if (b.get(i).asList()->get(1).asString()==name)
-        {
+    if (name == any){
+        if (b.size()!=0){
             return 1;
+        }else{
+            return 0;
         }
-    }
+    }else{
+        for (int i=0;i<b.size();i++)
+        {
+            if (b.get(i).asList()->get(1).asString()==name)
+            {
+                return 1;
+            }
+        }
     return 0;
+    }
 }
 


### PR DESCRIPTION
By default, the modules skip `planner` and operate as per year 2 demo. However, by changing the options `plans` in `ears`'s `ears.ini` and `use_ears` in `behaviorManager`'s `default.ini`, the use of the `planner` module can be activated.

`planner` extracts action plans from its `default.ini`, thus new plans can easily be created by hand or through learning. Existing plans synchronised with input from `ears` are `point` ("point to the crocodile") and `narrate` ("what did we do").