### PR TITLE
[WIP] ProactiveTagging - Allow sentence: This is the XYZ

### DIFF
--- a/main/app/attentionRelated/ears/conf/MainGrammar.xml
+++ b/main/app/attentionRelated/ears/conf/MainGrammar.xml
@@ -77,6 +77,7 @@
       <P>take</P>
       <P>give</P>
       <P>look at</P>
+      <P>this is</P>
     </L>
   </RULE>
 

--- a/main/src/modules/attentionRelated/proactiveTagging/src/proactiveTagging.cpp
+++ b/main/src/modules/attentionRelated/proactiveTagging/src/proactiveTagging.cpp
@@ -624,7 +624,7 @@ Bottle proactiveTagging::searchingEntity(const Bottle &bInput)
 {
     Bottle bOutput;
 
-    if (bInput.size() != 3)
+    if (bInput.size() != 4)
     {
         yInfo() << " proactiveTagging::searchingEntity | Problem in input size.";
         bOutput.addString("error");
@@ -634,7 +634,8 @@ Bottle proactiveTagging::searchingEntity(const Bottle &bInput)
 
     string sTypeTarget = bInput.get(1).toString();
     string sNameTarget = bInput.get(2).toString();
-    yInfo() << " Entity to find: " << sNameTarget;
+    bool verboseSearch = bInput.get(3).asInt() > 0;
+    yInfo() << " Entity to find: " << sNameTarget << "(Type: " << sTypeTarget << ", verbosity: " << verboseSearch << ")";
 
     int unknownEntitiesPresent = 0;
 
@@ -702,21 +703,23 @@ Bottle proactiveTagging::searchingEntity(const Bottle &bInput)
 
     // if there is several objects unknown (or at least one)
     string sSentence;
-    if(sTypeTarget == "object") {
-        sSentence = "I don't known which of these objects is a " + sNameTarget + ". Can you show me the " + sNameTarget;
-    } else if (sTypeTarget == "bodypart") {
-        sSentence = "I don't known my " + sNameTarget + ". Can you please touch my " + sNameTarget;
-    }
+    if(verboseSearch) {
+        if(sTypeTarget == "object") {
+            sSentence = "I don't known which of these objects is a " + sNameTarget + ". Can you show me the " + sNameTarget;
+        } else if (sTypeTarget == "bodypart") {
+            sSentence = "I don't known my " + sNameTarget + ". Can you please touch my " + sNameTarget;
+        }
 
-    //add name of the partner at the end of the question if defined
-    string partnerName = iCub->getPartnerName();
-    if(partnerName != defaultPartnerName){
-        sSentence += ", " + partnerName;
-    }
+        //add name of the partner at the end of the question if defined
+        string partnerName = iCub->getPartnerName();
+        if(partnerName != defaultPartnerName){
+            sSentence += ", " + partnerName;
+        }
 
-    iCub->lookAtPartner();
-    iCub->say(sSentence);
-    yInfo() << sSentence;
+        iCub->lookAtPartner();
+        iCub->say(sSentence);
+        yInfo() << sSentence;
+    }
 
     if(sTypeTarget == "object") {
         iCub->home();
@@ -765,7 +768,6 @@ Bottle proactiveTagging::searchingEntity(const Bottle &bInput)
 
     if (iCub->getABMClient()->Connect())
     {
-        //                yInfo() << "\t\t START POINTING OF: " << it.second.o.name();
         std::list<std::pair<std::string, std::string> > lArgument;
         lArgument.push_back(std::pair<std::string, std::string>("iCub", "agent"));
         lArgument.push_back(std::pair<std::string, std::string>("name", "predicate"));

--- a/main/src/modules/reactiveLayer/behaviorManager/include/followingOrder.h
+++ b/main/src/modules/reactiveLayer/behaviorManager/include/followingOrder.h
@@ -43,7 +43,7 @@ public:
     bool handleAction(string type, string target, string action);
     bool handleActionBP(string type, string target, string action);
     bool handleActionKS(string action, string type);
-    bool handleSearch(string type, string action);
+    bool handleSearch(string type, string action, bool verboseSearch);
     bool handleNarrate();
     bool handleGame(string type);
     bool handleEnd();

--- a/main/src/modules/reactiveLayer/behaviorManager/src/followingOrder.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/followingOrder.cpp
@@ -69,7 +69,7 @@ void FollowingOrder::run(Bottle args/*=Bottle()*/) {
     }
 
     //FollowingOrder implying objects
-    if ( (action == "point" || action == "look at" || action == "push") && type == "object"){
+    if ( (action == "point" || action == "look at" || action == "push" || action == "this is") && type == "object"){
         // Be careful: both handlePoint (point in response of a human order) and handlePointing (point what you know)
         if (sens->size()<2){
             iCub->say("I can't " + action + "if you don't tell me the object");
@@ -121,6 +121,11 @@ bool FollowingOrder::handleNarrate(){
 
 bool FollowingOrder::handleAction(string type, string target, string action) {
     yInfo() << "[handleAction] type: " << type << "target:" << target << "action:" << action;
+    if(action == "this is") {
+        yDebug() << "[handleAction] For action \"" + action + "\" there is nothing to do here. Return.";
+        return true;
+    }
+
     iCub->opc->checkout();
     yInfo() << " [handleAction]: opc checkout";
     list<Entity*> lEntities = iCub->opc->EntitiesCache();

--- a/main/src/modules/reactiveLayer/behaviorManager/src/followingOrder.cpp
+++ b/main/src/modules/reactiveLayer/behaviorManager/src/followingOrder.cpp
@@ -60,8 +60,12 @@ void FollowingOrder::run(Bottle args/*=Bottle()*/) {
     yInfo() << target;
 
     if ( target != "none" && type != "bodypart" && type != "kinematic structure" && type != "kinematic structure correspondence"){           //we dont have searchEntity for bodypart
+        bool verboseSearch=true;
+        if( action == "this is" ) {
+            verboseSearch=false;
+        }
         yInfo() << "there are objects to search!!!";
-        handleSearch(type, target);
+        handleSearch(type, target, verboseSearch);
     }
 
     //FollowingOrder implying objects
@@ -255,7 +259,7 @@ bool FollowingOrder::handleActionBP(string type, string target, string action) {
     return false;
 }
 
-bool FollowingOrder::handleSearch(string type, string target)
+bool FollowingOrder::handleSearch(string type, string target, bool verboseSearch)
 {
     // look if the object (from human order) exist and if not, trigger proactivetagging
 
@@ -291,6 +295,7 @@ bool FollowingOrder::handleSearch(string type, string target)
     cmd.addString("searchingEntity");
     cmd.addString(type);
     cmd.addString(target);
+    cmd.addInt(verboseSearch);
     rpc_out_port.write(cmd,rply);
     yDebug() << rply.toString();
 


### PR DESCRIPTION
This pull request addresses the problem of not being able to teach the robot the name of an object directly. So far, the robot can only learn the object proactively (i.e. self triggered) or after being asked to point to an unknown object.
Now, the human can say "This is the banana", then the robot will subsequently detect the pointing and say "Now I know this is the banana".
It uses the same logic as the following order for pointing, but the following is stripped out:
- Saying "I don't know which of these objects is the banana. Can you show me the banana please?"
- The subsequent pointing

To be tested before merging.

Tobi