### PR TITLE
Feature/upf/check objective

### DIFF
--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -28,7 +28,6 @@ dum-2post                        ( (() (is mug known)) )
 narrate-totactions               1
 narrate-objectiveState           (  )
 narrate-action1                  (narrate   _obj)
-<<<<<<< HEAD
 narrate-1pre                     (  )
 narrate-1post                    (  )
 

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -8,6 +8,7 @@ ABM                     true
 plans   (point dum give take showks showksc recognitionOrder narrate)
 
 point-totactions                 2
+point-objectiveState             (  )
 point-action1                    (tagging   _obj)
 point-1pre                       ( ((not) (is _obj known)) (() (is any present)) )
 point-1post                      ( (() (is _obj known)) (() (is _obj present)) )
@@ -16,6 +17,7 @@ point-2pre                       ( (() (is _obj known)) (() (is _obj present)) )
 point-2post                      ( (() (is _obj known)) (() (is _obj present)) )
 
 dum-totactions                   2
+dum-objectiveState               (  )
 dum-action1                      (dummy)
 dum-1pre                         ( ((not) (is mug known)) )
 dum-1post                        ( (() (is mug known)) )
@@ -24,11 +26,13 @@ dum-2pre                         ( (() (is mug known)) )
 dum-2post                        ( (() (is mug known)) )
 
 narrate-totactions               1
+narrate-objectiveState           (  )
 narrate-action1                  (narrate   _obj)
 narrate-1pre                     (  )
 narrate-1post                    (  )
 
 give-totactions                  2
+give-objectiveState              ( (is _obj HumanOnly) )
 give-action1                     (moveObject front _obj)
 give-1pre                        ( (() (is _obj present)) (() (is _obj RobotOnly)) )
 give-1post                       ( (() (is _obj present)) (() (is _obj Shared)) )
@@ -39,6 +43,7 @@ give-2post                       ( (() (is _obj present)) (() (is _obj HumanOnly
 give-2success                    ( "Well done, now you have the " _obj )
 
 take-totactions                  2
+take-objectiveState              ( (is _obj RobotOnly) )
 take-action1                     (ask push _obj)
 take-1pre                        ( (() (is _obj present)) (() (is _obj HumanOnly)) )
 take-1post                       ( (() (is _obj present)) (() (is _obj Shared)) )
@@ -49,16 +54,19 @@ take-2post                       ( (() (is _obj present)) (() (is _obj RobotOnly
 take-2success                    ( "Now I have the " _obj )
 
 showksc-totactions               1
+showksc-objectiveState           (  )
 showksc-action1                  (followingOrder show "kinematic structure correspondence")
 showksc-1pre                     (  )
 showksc-1post                    (  )
 
 showks-totactions                1
+showks-objectiveState            (  )
 showks-action1                   (followingOrder show "kinematic structure")
 showks-1pre                      (  )
 showks-1post                     (  )
 
 recognitionOrder-totactions      1
+recognitionOrder-objectiveState  (  )
 recognitionOrder-action1         (recognitionOrder)
 recognitionOrder-1pre            (  )
 recognitionOrder-1post           (  )

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -32,7 +32,7 @@ narrate-1pre                     (  )
 narrate-1post                    (  )
 
 give-totactions                  2
-give-objectiveState              ( () (is _obj HumanOnly) )
+give-objectiveState              ( (() (is _obj HumanOnly)) )
 give-action1                     (moveObject front _obj)
 give-1pre                        ( (() (is _obj present)) (() (is _obj RobotOnly)) )
 give-1post                       ( (() (is _obj present)) (() (is _obj Shared)) )
@@ -43,7 +43,7 @@ give-2post                       ( (() (is _obj present)) (() (is _obj HumanOnly
 give-2success                    ( "Well done, now you have the " _obj )
 
 take-totactions                  2
-take-objectiveState              ( () (is _obj RobotOnly) )
+take-objectiveState              ( (() (is _obj RobotOnly)) )
 take-action1                     (ask push _obj)
 take-1pre                        ( (() (is _obj present)) (() (is _obj HumanOnly)) )
 take-1post                       ( (() (is _obj present)) (() (is _obj Shared)) )

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -28,6 +28,7 @@ dum-2post                        ( (() (is mug known)) )
 narrate-totactions               1
 narrate-objectiveState           (  )
 narrate-action1                  (narrate   _obj)
+<<<<<<< HEAD
 narrate-1pre                     (  )
 narrate-1post                    (  )
 

--- a/main/app/contextualLayer/planner/conf/default.ini
+++ b/main/app/contextualLayer/planner/conf/default.ini
@@ -32,7 +32,7 @@ narrate-1pre                     (  )
 narrate-1post                    (  )
 
 give-totactions                  2
-give-objectiveState              ( (is _obj HumanOnly) )
+give-objectiveState              ( () (is _obj HumanOnly) )
 give-action1                     (moveObject front _obj)
 give-1pre                        ( (() (is _obj present)) (() (is _obj RobotOnly)) )
 give-1post                       ( (() (is _obj present)) (() (is _obj Shared)) )
@@ -43,7 +43,7 @@ give-2post                       ( (() (is _obj present)) (() (is _obj HumanOnly
 give-2success                    ( "Well done, now you have the " _obj )
 
 take-totactions                  2
-take-objectiveState              ( (is _obj RobotOnly) )
+take-objectiveState              ( () (is _obj RobotOnly) )
 take-action1                     (ask push _obj)
 take-1pre                        ( (() (is _obj present)) (() (is _obj HumanOnly)) )
 take-1post                       ( (() (is _obj present)) (() (is _obj Shared)) )

--- a/main/src/modules/contextualLayer/planner/include/planner.h
+++ b/main/src/modules/contextualLayer/planner/include/planner.h
@@ -22,10 +22,12 @@ private:
     vector<string> type_list;
     vector<int> priority_list;
     vector<int> actionPos_list;
+    vector<int> planNr_list;
     Bottle grpPlans;
     Bottle set;
     int id;
     int attemptCnt;
+    int planNr;
 
     // bool bShouldListen;
 

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -659,47 +659,105 @@ bool Planner::updateModule() {
             }
             yDebug() << "sentence_success constructed";
 
-            // checking for post condition fulfillment.
+            Bottle objectives = *grpPlans.find(planName + "-objectiveState").asList();
+
+            // checking for ultimate state fulfillment.
             int stateCheck = 1;
-            for (int k = 0; k < stateOI.size(); k++)
+            if (objectives.size() != 0)
             {
-                Bottle bot;
-                Bottle rep;
-                bot.clear();
-                rep.clear();
-
-                Bottle* msg = stateOI.get(k).asList()->get(1).asList();
-                for (int i = 0; i < msg->size(); i++)
+                for (int Ob = 0; Ob < objectives.size(); Ob++)
                 {
-                    string aux = msg->get(i).asString();
-                    for (int j = 0; j < args.size(); j++)
-                    {
-                        if (args.get(j).asString() == msg->get(i).asString())
-                        {
-                            aux = object_list[0];
-                        }
-                    }
-                    bot.addString(aux);
-                }
+                    Bottle bot;
+                    Bottle rep;
+                    bot.clear();
+                    rep.clear();
 
+                    Bottle* msg = objectives.get(Ob).asList()->get(1).asList();
+                    for (int i = 0; i < msg->size(); i++)
+                    {
+                        string aux = msg->get(i).asString();
+                        for (int j = 0; j < args.size(); j++)
+                        {
+                            if (args.get(j).asString() == msg->get(i).asString())
+                            {
+                                aux = object_list[0];
+                            }
+                        }
+                        bot.addString(aux);
+                    }
+
+<<<<<<< HEAD
                 getState.write(bot, rep);
                 yDebug() << "bot:"<<bot.toString();
                 bot.clear();
                 bool indiv;
                 string attach = stateOI.get(k).asList()->get(0).toString();
+=======
+                    getState.write(bot, rep);
+                    yDebug() << bot.toString();
+                    bot.clear();
+                    bool indiv;
+                    string attach = objectives.get(Ob).asList()->get(0).toString();
+>>>>>>> [planner] able to consider action as complete if main goal is reached.
 
-                if (attach == "not")
-                {
-                    yDebug() << "not";
-                    indiv = !rep.get(1).asBool();
-                }
-                else
-                {
-                    indiv = rep.get(1).asBool();
-                }
+                    if (attach == "not")
+                    {
+                        yDebug() << "not";
+                        indiv = !rep.get(1).asBool();
+                    }
+                    else
+                    {
+                        indiv = rep.get(1).asBool();
+                    }
 
-                stateCheck = indiv && stateCheck;
-                yDebug() << "State is" << stateCheck;
+                    stateCheck = indiv && stateCheck;
+                    yDebug() << "objective of the plan is already complete: " << stateCheck;
+                }
+            }
+
+            // checking for post condition fulfillment if ultimate state is not
+            if (!stateCheck)
+            {
+                for (int k = 0; k < stateOI.size(); k++)
+                {
+                    Bottle bot;
+                    Bottle rep;
+                    bot.clear();
+                    rep.clear();
+
+                    Bottle* msg = stateOI.get(k).asList()->get(1).asList();
+                    for (int i = 0; i < msg->size(); i++)
+                    {
+                        string aux = msg->get(i).asString();
+                        for (int j = 0; j < args.size(); j++)
+                        {
+                            if (args.get(j).asString() == msg->get(i).asString())
+                            {
+                                aux = object_list[0];
+                            }
+                        }
+                        bot.addString(aux);
+                    }
+
+                    getState.write(bot, rep);
+                    yDebug() << bot.toString();
+                    bot.clear();
+                    bool indiv;
+                    string attach = stateOI.get(k).asList()->get(0).toString();
+
+                    if (attach == "not")
+                    {
+                        yDebug() << "not";
+                        indiv = !rep.get(1).asBool();
+                    }
+                    else
+                    {
+                        indiv = rep.get(1).asBool();
+                    }
+
+                    stateCheck = indiv && stateCheck;
+                    yDebug() << "State is" << stateCheck;
+                }
             }
 
             if (actionCompleted && stateCheck)

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -685,20 +685,11 @@ bool Planner::updateModule() {
                         }
                         bot.addString(aux);
                     }
-
-<<<<<<< HEAD
-                getState.write(bot, rep);
-                yDebug() << "bot:"<<bot.toString();
-                bot.clear();
-                bool indiv;
-                string attach = stateOI.get(k).asList()->get(0).toString();
-=======
                     getState.write(bot, rep);
                     yDebug() << bot.toString();
                     bot.clear();
                     bool indiv;
                     string attach = objectives.get(Ob).asList()->get(0).toString();
->>>>>>> [planner] able to consider action as complete if main goal is reached.
 
                     if (attach == "not")
                     {

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -697,8 +697,6 @@ bool Planner::updateModule() {
                 {
                     Bottle bot;
                     Bottle rep;
-                    bot.clear();
-                    rep.clear();
 
                     Bottle* msg = objectives.get(Ob).asList()->get(1).asList();
                     for (int i = 0; i < msg->size(); i++)
@@ -740,8 +738,6 @@ bool Planner::updateModule() {
                 {
                     Bottle bot;
                     Bottle rep;
-                    bot.clear();
-                    rep.clear();
 
                     Bottle* msg = stateOI.get(k).asList()->get(1).asList();
                     for (int i = 0; i < msg->size(); i++)

--- a/main/src/modules/contextualLayer/planner/src/planner.cpp
+++ b/main/src/modules/contextualLayer/planner/src/planner.cpp
@@ -639,13 +639,11 @@ bool Planner::updateModule() {
             }
 
             // check for completed state
-            yDebug() << "checking for completion from SM";
             string planName = plan_list[0];
             Bottle stateOI = *grpPlans.find(planName + "-" + to_string(actionPos_list[0]) + "post").asList();
             args.clear();
             args = *grpPlans.find(planName + "-action" + to_string(actionPos_list[0])).asList();
             args = args.tail();
-            yDebug() << "args: " << args.toString();
 
             Bottle emptyBottle("()");
             Bottle sent = *grpPlans.check(planName + "-" + to_string(actionPos_list[0]) + "success", emptyBottle.get(0)).asList();
@@ -662,7 +660,7 @@ bool Planner::updateModule() {
             Bottle objectives = *grpPlans.find(planName + "-objectiveState").asList();
 
             // checking for ultimate state fulfillment.
-            int stateCheck = 1;
+            bool stateCheck = true;
             if (objectives.size() != 0)
             {
                 for (int Ob = 0; Ob < objectives.size(); Ob++)
@@ -693,7 +691,6 @@ bool Planner::updateModule() {
 
                     if (attach == "not")
                     {
-                        yDebug() << "not";
                         indiv = !rep.get(1).asBool();
                     }
                     else
@@ -706,7 +703,7 @@ bool Planner::updateModule() {
                 }
             }
 
-            // checking for post condition fulfillment if ultimate state is not
+            // checking for post condition fulfillment if ultimate state is not met
             if (!stateCheck)
             {
                 for (int k = 0; k < stateOI.size(); k++)
@@ -738,7 +735,6 @@ bool Planner::updateModule() {
 
                     if (attach == "not")
                     {
-                        yDebug() << "not";
                         indiv = !rep.get(1).asBool();
                     }
                     else
@@ -754,7 +750,7 @@ bool Planner::updateModule() {
             if (actionCompleted && stateCheck)
             {
                 iCub->say(success_sentence);
-                yInfo() << "removing action " << *action_list.begin();
+                yDebug() << "removing actions";
                 action_list.erase(action_list.begin());
                 priority_list.erase(priority_list.begin());
                 plan_list.erase(plan_list.begin());
@@ -762,6 +758,20 @@ bool Planner::updateModule() {
                 type_list.erase(type_list.begin());
                 actionPos_list.erase(actionPos_list.begin());
                 attemptCnt = 0;
+
+                for (unsigned int extra = 0; extra < actionPos_list.size(); extra++)
+                {
+                    if (actionPos_list[0] != 1)
+                    {
+                        action_list.erase(action_list.begin());
+                        priority_list.erase(priority_list.begin());
+                        plan_list.erase(plan_list.begin());
+                        object_list.erase(object_list.begin());
+                        type_list.erase(type_list.begin());
+                        actionPos_list.erase(actionPos_list.begin());
+                    }
+                    else { break; }
+                }
 
                 yInfo() << "action completed and removed from lists.";
             }


### PR DESCRIPTION
Only processing within the module is changed; all communications to other modules are the same. This change makes the `planner` more robust in handling plans. It can now retroactively remove groups of actions (when they are part of the same plan) from its list if they are no longer relevant to achieving the goal of the plan.

Example scenario: robot wants an object in its reachable space, but it is in the human's space. The plan is thus to ask the human to push the object into the shared space, followed by pulling it into its own space. However, the human overshoots and pushes the object into the robot's space. The action of pulling the object is now irrelevant and is skipped.

@pattacini sorry but I think I messed up the creation and pushing of this new branch, so the history is super long.