### PR TITLE
[WIP] Use reachableArea.py to obtain reachable area

### DIFF
--- a/main/app/demos/scripts/wysiwyd-demo-y2-inserm.xml
+++ b/main/app/demos/scripts/wysiwyd-demo-y2-inserm.xml
@@ -128,10 +128,17 @@
     </module>
 
     <module>
+        <name>reachableArea.py</name>
+        <parameters></parameters>
+        <node>icub-b3</node>
+    </module>
+
+    <module>
         <name>iol2opc</name>
         <parameters></parameters>
         <node>icub-cuda</node>
         <dependencies>
+            <port timeout="10">/reachableArea/rpc</port>
             <port timeout="10">/OPC/rpc</port>
             <port timeout="10">/himrepClassifier/rpc</port>
             <port timeout="10">/SFM/rpc</port>
@@ -466,6 +473,11 @@
     <connection>
         <from>/iol2opc/imgClassifier:o</from>
         <to>/himrepClassifier/img:i</to>
+        <protocol>tcp</protocol>
+    </connection>
+    <connection>
+        <from>/iol2opc/getReachableArea:rpc</from>
+        <to>/reachableArea/rpc</to>
         <protocol>tcp</protocol>
     </connection>
     <connection>

--- a/main/src/modules/systemVisual/iol2opc/include/module.h
+++ b/main/src/modules/systemVisual/iol2opc/include/module.h
@@ -183,6 +183,7 @@ protected:
     RpcServer  rpcPort;
     RpcClient  rpcClassifier;
     RpcClient  rpcGet3D;
+    RpcClient  rpcGetReachableArea;
     OPCClient *opc;
 
     BufferedPort<Bottle>             blobExtractor;

--- a/main/src/modules/systemVisual/iol2opc/src/module.cpp
+++ b/main/src/modules/systemVisual/iol2opc/src/module.cpp
@@ -665,6 +665,21 @@ void IOL2OPCBridge::doLocalization()
 }
 
 ObjectArea IOL2OPCBridge::getReachableArea(const Vector &objpos) {
+    if(rpcGetReachableArea.getOutputCount()>0) {
+        Bottle bCmd, bReply;
+        bCmd.addString("get_area");
+        bCmd.addDouble(objpos[0]);
+        bCmd.addDouble(objpos[1]);
+        bCmd.addDouble(objpos[2]);
+        rpcGetReachableArea.write(bCmd, bReply);
+        if(bReply.get(0).asString()=="nack") {
+            yError() << "Got nack from getReachableArea module";
+        } else {
+            return Object::stringToObjectArea(bReply.get(1).asString());
+        }
+    }
+
+    yWarning() << "Not connected to getReachableArea module, use default procedure";
     if ((objpos[0]>human_area_x_bounds[0]) && (objpos[0]<human_area_x_bounds[1]) &&
         (objpos[1]>human_area_y_bounds[0]) && (objpos[1]<human_area_y_bounds[1])) {
         return ObjectArea::HUMAN;
@@ -905,6 +920,7 @@ bool IOL2OPCBridge::configure(ResourceFinder &rf)
     rpcClassifier.open(("/"+name+"/classify:rpc").c_str());
     rpcGet3D.open(("/"+name+"/get3d:rpc").c_str());
     getClickPort.open(("/"+name+"/getClick:i").c_str());
+    rpcGetReachableArea.open(("/"+name+"/getReachableArea:rpc").c_str());
 
     setBounds(rf, skim_blobs_x_bounds,  "skim_blobs_x_bounds",  -0.70, -0.10);
     setBounds(rf, skim_blobs_y_bounds,  "skim_blobs_y_bounds",  -0.30, -0.30);


### PR DESCRIPTION
This PR modifies `iol2opc` such that the reachable area is retrieved from a little Python script. For now, the Python script returns the very same reachable area (using the same computations) as `iol2opc` used to do. The plan is that the script can be extended to employ the self-learned reachable area.

/cc @hjchang @maxime-petit @Aneoshun